### PR TITLE
chore: update LICENSE to clean MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,52 +1,21 @@
-FreshGuard - Open Core Licensing
+MIT License
 
-The FreshGuard project uses dual licensing:
+Copyright (c) 2025 FreshGuard
 
-================================================================================
-1. CORE PACKAGE (packages/core/, packages/types/)
-================================================================================
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-   MIT License - See packages/core/LICENSE and packages/types/LICENSE
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-   - Open source, free to self-host, modify, and distribute
-   - Used by the open source community and self-hosters
-   - Includes: monitoring engine, connectors, database schema
-
-================================================================================
-2. CLOUD PACKAGE (packages/cloud/)
-================================================================================
-
-   Proprietary License - See packages/cloud/LICENSE
-
-   - The multi-tenant SaaS implementation is proprietary
-   - Covers: multi-tenant orchestration, scheduler, auth, dashboard
-   - Not available for self-hosting or redistribution
-   - Available as managed service at https://freshguard.dev
-
-================================================================================
-Summary
-================================================================================
-
-You may:
-  ✅ Use @thias-se/freshguard-core under MIT license (self-hosting)
-  ✅ Contribute to the open source core
-  ✅ Build commercial products using @thias-se/freshguard-core
-  ✅ Modify and redistribute @thias-se/freshguard-core
-
-You may NOT:
-  ❌ Copy or redistribute packages/cloud/
-  ❌ Self-host the cloud package
-  ❌ Extract the multi-tenant architecture
-
-For questions or licensing inquiries:
-- Open source: https://github.com/freshguard/freshguard/discussions
-- Commercial: legal@freshguard.dev
-
-================================================================================
-
-This dual licensing model allows us to:
-1. Provide a free, open source monitoring engine for the community
-2. Fund development through our managed SaaS offering
-3. Maintain a sustainable business while giving back to open source
-
-Thank you for using FreshGuard!
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Remove dual licensing references and cloud package mentions.
This repository contains only MIT-licensed open source code.