### PR TITLE
chore: migrate from thias-se to freshguard-dev org

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -85,7 +85,7 @@ jobs:
           pnpm install ${{ github.workspace }}
           node --input-type=module -e "
             try {
-              const pkg = await import('@thias-se/freshguard-core');
+              const pkg = await import('@freshguard/freshguard-core');
               console.log('✅ Package can be imported successfully');
               console.log('Available exports:', Object.keys(pkg));
               process.exit(0);

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -369,7 +369,7 @@ jobs:
           echo "" >> SBOM.md
           echo "**Generated:** $(date -u)" >> SBOM.md
           echo "**Version:** ${{ steps.extract_version.outputs.version }}" >> SBOM.md
-          echo "**Package:** @thias-se/freshguard-core" >> SBOM.md
+          echo "**Package:** @freshguard/freshguard-core" >> SBOM.md
           echo "" >> SBOM.md
           echo "## Security Information" >> SBOM.md
           echo "" >> SBOM.md
@@ -404,7 +404,7 @@ jobs:
             ## Installation
 
             ```bash
-            pnpm install @thias-se/freshguard-core@${{ steps.extract_version.outputs.version }}
+            pnpm install @freshguard/freshguard-core@${{ steps.extract_version.outputs.version }}
             ```
 
             ## Security Verification
@@ -412,10 +412,10 @@ jobs:
             Verify package signature:
             ```bash
             # Download signature bundle from this release
-            cosign verify-blob --bundle thias-se-freshguard-core-${{ steps.extract_version.outputs.version }}.tgz.cosign.bundle \
+            cosign verify-blob --bundle freshguard-freshguard-core-${{ steps.extract_version.outputs.version }}.tgz.cosign.bundle \
               --certificate-identity-regexp=".*" \
               --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-              thias-se-freshguard-core-${{ steps.extract_version.outputs.version }}.tgz
+              freshguard-freshguard-core-${{ steps.extract_version.outputs.version }}.tgz
             ```
 
             ## What's Changed
@@ -455,10 +455,10 @@ jobs:
           echo '{"name":"test-install","version":"1.0.0","type":"module"}' > package.json
 
           echo "Testing published packages..."
-          pnpm install @thias-se/freshguard-core@${{ needs.publish.outputs.version }}
+          pnpm install @freshguard/freshguard-core@${{ needs.publish.outputs.version }}
 
           node -e "
-            import('@thias-se/freshguard-core').then(({ checkFreshness, createDatabase, DataSourceType }) => {
+            import('@freshguard/freshguard-core').then(({ checkFreshness, createDatabase, DataSourceType }) => {
               console.log('✅ Published package works correctly');
               console.log('✅ checkFreshness:', typeof checkFreshness);
               console.log('✅ createDatabase:', typeof createDatabase);

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Open source data pipeline freshness monitoring engine for self-hosting.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![pnpm version](https://img.shields.io/npm/v/@thias-se/freshguard-core.svg)](https://www.npmjs.com/package/@thias-se/freshguard-core)
+[![pnpm version](https://img.shields.io/npm/v/@freshguard/freshguard-core.svg)](https://www.npmjs.com/package/@freshguard/freshguard-core)
 
 ## What is FreshGuard Core?
 
@@ -46,14 +46,14 @@ FreshGuard Core includes basic security protections for self-hosted deployments:
 ### 1. Install
 
 ```bash
-pnpm install @thias-se/freshguard-core
+pnpm install @freshguard/freshguard-core
 ```
 
 ### 2. Check Freshness
 
 ```typescript
-import { checkFreshness, PostgresConnector } from '@thias-se/freshguard-core';
-import type { MonitoringRule } from '@thias-se/freshguard-core';
+import { checkFreshness, PostgresConnector } from '@freshguard/freshguard-core';
+import type { MonitoringRule } from '@freshguard/freshguard-core';
 
 // Connect to your database
 const connector = new PostgresConnector({
@@ -91,7 +91,7 @@ if (result.status === 'alert') {
 ### 3. Check Volume Anomalies
 
 ```typescript
-import { checkVolumeAnomaly, PostgresConnector } from '@thias-se/freshguard-core';
+import { checkVolumeAnomaly, PostgresConnector } from '@freshguard/freshguard-core';
 
 const connector = new PostgresConnector({
   host: process.env.DB_HOST!,
@@ -111,7 +111,7 @@ if (result.status === 'alert') {
 ### 4. Monitor Schema Changes
 
 ```typescript
-import { checkSchemaChanges, PostgresConnector } from '@thias-se/freshguard-core';
+import { checkSchemaChanges, PostgresConnector } from '@freshguard/freshguard-core';
 
 const schemaRule: MonitoringRule = {
   id: 'users-schema',
@@ -177,7 +177,7 @@ FreshGuard tracks execution history for volume anomaly detection and monitoring 
 ### Quick Setup (Zero Configuration)
 
 ```typescript
-import { createMetadataStorage, checkVolumeAnomaly, PostgresConnector } from '@thias-se/freshguard-core';
+import { createMetadataStorage, checkVolumeAnomaly, PostgresConnector } from '@freshguard/freshguard-core';
 
 // Create database connector
 const connector = new PostgresConnector({
@@ -241,7 +241,7 @@ import {
   QueryError,
   ConfigurationError,
   MonitoringError
-} from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
 
 try {
   const result = await checkFreshness(connector, rule);
@@ -360,7 +360,7 @@ Want these features? Check out **[FreshGuard Cloud](https://freshguard.dev)** - 
 
 FreshGuard uses an **Open Core** model:
 
-- **`@thias-se/freshguard-core`** (this package) - MIT licensed, open source monitoring engine
+- **`@freshguard/freshguard-core`** (this package) - MIT licensed, open source monitoring engine
 - **`freshguard`** - Proprietary multi-tenant SaaS (optional)
 
 You can self-host the core or use our managed cloud service.
@@ -374,7 +374,7 @@ We welcome contributions! See [CONTRIBUTING.md](docs/CONTRIBUTING.md).
 ### 📊 Database Connections
 
 ```typescript
-import { PostgresConnector, BigQueryConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector, BigQueryConnector } from '@freshguard/freshguard-core';
 
 // PostgreSQL connection
 const pgConfig = {
@@ -400,8 +400,8 @@ const bigquery = new BigQueryConnector(bqConfig);
 ### 🔔 Custom Alerting
 
 ```typescript
-import { checkFreshness } from '@thias-se/freshguard-core';
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { checkFreshness } from '@freshguard/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 import { sendSlackAlert } from './alerts.js';
 
 // Database connection
@@ -426,8 +426,8 @@ if (result.status === 'alert') {
 ### 📅 Scheduled Monitoring
 
 ```typescript
-import { checkFreshness, checkVolumeAnomaly, checkSchemaChanges } from '@thias-se/freshguard-core';
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { checkFreshness, checkVolumeAnomaly, checkSchemaChanges } from '@freshguard/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 import cron from 'node-cron';
 
 const connector = new PostgresConnector({
@@ -445,7 +445,7 @@ cron.schedule('*/5 * * * *', async () => {
     console.log(`✅ Check result: ${result.status}`);
   } catch (error) {
     // Import error classes for specific handling
-    const { SecurityError, ConnectionError, TimeoutError } = require('@thias-se/freshguard-core');
+    const { SecurityError, ConnectionError, TimeoutError } = require('@freshguard/freshguard-core');
 
     if (error instanceof ConnectionError) {
       console.error(`🔌 Database connection failed: ${error.message}`);
@@ -521,7 +521,7 @@ import {
   QueryError,
   ConfigurationError,
   MonitoringError
-} from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
 ```
 
 ### Error Classes

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ FreshGuard Core is an open-source MIT-licensed data pipeline freshness monitorin
 
 ```bash
 # Clone the repository
-git clone https://github.com/thias-se/freshguard-core.git
+git clone https://github.com/freshguard-dev/freshguard-core.git
 cd freshguard-core
 
 # Install dependencies

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -34,7 +34,7 @@ node your-app.js
 Pass debug configuration directly to monitoring functions:
 
 ```javascript
-import { checkFreshness, PostgresConnector } from '@thias-se/freshguard-core';
+import { checkFreshness, PostgresConnector } from '@freshguard/freshguard-core';
 
 // Create connector
 const connector = new PostgresConnector({
@@ -442,7 +442,7 @@ const result = await checkFreshness(connector, rule, metadata, createFreshGuardC
 
 ### Unit Tests
 ```javascript
-import { checkFreshness, PostgresConnector } from '@thias-se/freshguard-core';
+import { checkFreshness, PostgresConnector } from '@freshguard/freshguard-core';
 
 test('should provide debug information on failure', async () => {
   const config = {

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -7,13 +7,13 @@ Complete guide for integrating FreshGuard Core's security features into your pro
 ### Installation
 
 ```bash
-pnpm add @thias-se/freshguard-core
+pnpm add @freshguard/freshguard-core
 ```
 
 ### Basic Setup
 
 ```typescript
-import { PostgresConnector, SecurityConfig } from '@thias-se/freshguard-core';
+import { PostgresConnector, SecurityConfig } from '@freshguard/freshguard-core';
 
 const connector = new PostgresConnector({
   host: process.env.DB_HOST!,
@@ -38,7 +38,7 @@ console.log(`Orders: ${rowCount} rows, last update: ${lastUpdate}`);
 Monitor database schema changes to detect unexpected modifications:
 
 ```typescript
-import { checkSchemaChanges, createMetadataStorage } from '@thias-se/freshguard-core';
+import { checkSchemaChanges, createMetadataStorage } from '@freshguard/freshguard-core';
 
 // Create metadata storage for baseline persistence
 const metadataStorage = await createMetadataStorage({
@@ -175,7 +175,7 @@ const stagingSecurityConfig: Partial<SecurityConfig> = {
 Automatically analyzes and scores queries for security and performance risks.
 
 ```typescript
-import { createQueryAnalyzer } from '@thias-se/freshguard-core';
+import { createQueryAnalyzer } from '@freshguard/freshguard-core';
 
 const analyzer = createQueryAnalyzer({
   maxRiskScore: 70,              // Block queries above this risk score
@@ -199,7 +199,7 @@ console.log('Recommendations:', analysis.recommendations); // Optimization tips
 High-performance table metadata caching with automatic expiry.
 
 ```typescript
-import { createSchemaCache } from '@thias-se/freshguard-core';
+import { createSchemaCache } from '@freshguard/freshguard-core';
 
 const cache = createSchemaCache({
   maxEntries: 1000,           // Cache up to 1000 table schemas
@@ -223,7 +223,7 @@ console.log(`Cache hit ratio: ${stats.hitRatio}%`);
 Automatic failure protection and recovery.
 
 ```typescript
-import { createCircuitBreaker } from '@thias-se/freshguard-core';
+import { createCircuitBreaker } from '@freshguard/freshguard-core';
 
 const circuitBreaker = createCircuitBreaker({
   name: 'database-connection',
@@ -257,7 +257,7 @@ import {
   ValidationError,
   TimeoutError,
   CircuitBreakerOpenError
-} from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
 
 try {
   const result = await connector.getRowCount('suspicious_table');
@@ -292,7 +292,7 @@ try {
 ### Structured Logging Setup
 
 ```typescript
-import { createDatabaseLogger } from '@thias-se/freshguard-core';
+import { createDatabaseLogger } from '@freshguard/freshguard-core';
 
 // Configure structured logging
 const logger = createDatabaseLogger('postgres', {
@@ -320,7 +320,7 @@ logger.info('Custom operation', {
 ### Metrics Collection
 
 ```typescript
-import { createComponentMetrics } from '@thias-se/freshguard-core';
+import { createComponentMetrics } from '@freshguard/freshguard-core';
 
 // Set up metrics collection
 const metrics = createComponentMetrics('freshguard-integration');
@@ -340,7 +340,7 @@ const prometheusMetrics = metrics.exportPrometheus();
 ### PostgreSQL
 
 ```typescript
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 const postgres = new PostgresConnector({
   host: 'localhost',
@@ -361,7 +361,7 @@ const postgres = new PostgresConnector({
 ### BigQuery
 
 ```typescript
-import { BigQueryConnector } from '@thias-se/freshguard-core';
+import { BigQueryConnector } from '@freshguard/freshguard-core';
 
 const bigquery = new BigQueryConnector({
   projectId: process.env.GOOGLE_CLOUD_PROJECT,
@@ -379,7 +379,7 @@ const bigquery = new BigQueryConnector({
 ### Snowflake
 
 ```typescript
-import { SnowflakeConnector } from '@thias-se/freshguard-core';
+import { SnowflakeConnector } from '@freshguard/freshguard-core';
 
 const snowflake = new SnowflakeConnector({
   account: process.env.SNOWFLAKE_ACCOUNT,
@@ -399,7 +399,7 @@ const snowflake = new SnowflakeConnector({
 ### DuckDB (Embedded)
 
 ```typescript
-import { DuckDBConnector } from '@thias-se/freshguard-core';
+import { DuckDBConnector } from '@freshguard/freshguard-core';
 
 const duckdb = new DuckDBConnector({
   path: './data/analytics.duckdb',  // File path for embedded DuckDB
@@ -584,7 +584,7 @@ try {
 ### Unit Testing
 
 ```typescript
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 describe('FreshGuard Integration', () => {
   let connector: PostgresConnector;
@@ -680,8 +680,8 @@ const connector = new PostgresConnector(config, {
 
 ## Support and Resources
 
-- **GitHub Issues**: [Report bugs or request features](https://github.com/thias-se/freshguard-core/issues)
-- **Documentation**: [Complete docs](https://github.com/thias-se/freshguard-core/docs)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/freshguard-dev/freshguard-core/issues)
+- **Documentation**: [Complete docs](https://github.com/freshguard-dev/freshguard-core/docs)
 - **Security Guide**: [Self-hosting security guide](./SECURITY_FOR_SELF_HOSTERS.md)
 - **Contributing**: [Development guide](./CONTRIBUTING.md)
 

--- a/docs/METADATA_STORAGE.md
+++ b/docs/METADATA_STORAGE.md
@@ -7,7 +7,7 @@ FreshGuard Core uses metadata storage to track execution history and schema base
 By default, FreshGuard uses DuckDB for metadata storage with no configuration required:
 
 ```typescript
-import { createMetadataStorage, checkVolumeAnomaly, PostgresConnector } from '@thias-se/freshguard-core';
+import { createMetadataStorage, checkVolumeAnomaly, PostgresConnector } from '@freshguard/freshguard-core';
 
 // Create secure connector
 const connector = new PostgresConnector({
@@ -183,7 +183,7 @@ import {
   checkFreshness,
   checkVolumeAnomaly,
   checkSchemaChanges
-} from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
 
 // Setup
 const connector = new PostgresConnector({
@@ -246,7 +246,7 @@ await metadataStorage.close();
 ### Production Monitoring Loop
 ```typescript
 import cron from 'node-cron';
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 let metadataStorage: MetadataStorage;
 let connector: PostgresConnector;

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -23,14 +23,14 @@ Guide for self-hosting FreshGuard Core in your own environment.
 ### Installation
 
 ```bash
-pnpm add @thias-se/freshguard-core
+pnpm add @freshguard/freshguard-core
 ```
 
 ### Basic Setup
 
 ```typescript
-import { PostgresConnector, checkFreshness } from '@thias-se/freshguard-core';
-import type { MonitoringRule } from '@thias-se/freshguard-core';
+import { PostgresConnector, checkFreshness } from '@freshguard/freshguard-core';
+import type { MonitoringRule } from '@freshguard/freshguard-core';
 
 // Basic configuration
 const connector = new PostgresConnector({
@@ -69,7 +69,7 @@ FreshGuard Core includes basic security features that are enabled by default.
 ### Connection Security
 
 ```typescript
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 // Secure connection configuration
 const connector = new PostgresConnector({
@@ -181,7 +181,7 @@ LOG_LEVEL=info
 Create a basic health check for your monitoring:
 
 ```typescript
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 const connector = new PostgresConnector({
   host: process.env.DB_HOST!,
@@ -236,8 +236,8 @@ import {
   checkFreshness,
   checkVolumeAnomaly,
   createMetadataStorage
-} from '@thias-se/freshguard-core';
-import type { MonitoringRule } from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
+import type { MonitoringRule } from '@freshguard/freshguard-core';
 
 // Set up database connection
 const connector = new PostgresConnector({
@@ -338,8 +338,8 @@ if (result.status === 'alert') {
 
 - **Integration Guide**: [Implementation examples](./INTEGRATION_GUIDE.md)
 - **Security Guide**: [Security considerations](./SECURITY_FOR_SELF_HOSTERS.md)
-- **GitHub Issues**: [Report bugs or request features](https://github.com/thias-se/freshguard-core/issues)
-- **GitHub Discussions**: [Ask questions and share experiences](https://github.com/thias-se/freshguard-core/discussions)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/freshguard-dev/freshguard-core/issues)
+- **GitHub Discussions**: [Ask questions and share experiences](https://github.com/freshguard-dev/freshguard-core/discussions)
 
 ## Next Steps
 

--- a/examples/basic-freshness-check/README.md
+++ b/examples/basic-freshness-check/README.md
@@ -209,7 +209,7 @@ basic-freshness-check/
 
 **setup.ts** - Secure connector setup and verification:
 ```typescript
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 // Create secure connector with security features
 const connector = new PostgresConnector(dbConfig, {
@@ -229,7 +229,7 @@ import {
   PostgresConnector,
   checkFreshness,
   checkVolumeAnomaly
-} from '@thias-se/freshguard-core';
+} from '@freshguard/freshguard-core';
 
 // Security configuration for production
 const securityConfig = {
@@ -302,7 +302,7 @@ UPDATE orders SET updated_at = '2024-01-01 00:00:00';
 **Secure Scheduling:**
 ```typescript
 import cron from 'node-cron';
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 // Production security configuration
 const prodSecurityConfig = {

--- a/examples/basic-freshness-check/monitor.ts
+++ b/examples/basic-freshness-check/monitor.ts
@@ -24,7 +24,7 @@ import {
   type CheckResult,
   type MetadataStorage
   } from '../../dist';
-//} from '@thias-se/freshguard-core';
+//} from '@freshguard/freshguard-core';
 import { config } from 'dotenv';
 
 // Load environment variables
@@ -378,7 +378,7 @@ FRESHGUARD_ENABLE_QUERY_ANALYSIS=true
   console.log('2. Secure Scheduling:');
   console.log(`
 import cron from 'node-cron';
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 
 // Production security config
 const prodConfig = {

--- a/examples/basic-freshness-check/package.json
+++ b/examples/basic-freshness-check/package.json
@@ -12,7 +12,7 @@
     "docker:down": "docker-compose down"
   },
   "dependencies": {
-    "@thias-se/freshguard-core": "^0.5.2",
+    "@freshguard/freshguard-core": "^0.5.2",
     "dotenv": "^16.6.1"
   },
   "devDependencies": {

--- a/examples/basic-freshness-check/setup.ts
+++ b/examples/basic-freshness-check/setup.ts
@@ -12,7 +12,7 @@
  * Updated for FreshGuard Core v0.5.2 with Phase 2 Security Implementation
  */
 
-import { PostgresConnector } from '@thias-se/freshguard-core';
+import { PostgresConnector } from '@freshguard/freshguard-core';
 import { config } from 'dotenv';
 
 // Load environment variables

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@thias-se/freshguard-core",
+  "name": "@freshguard/freshguard-core",
   "version": "0.11.2",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
@@ -90,7 +90,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/thias-se/freshguard-core.git"
+    "url": "https://github.com/freshguard-dev/freshguard-core.git"
   },
   "publishConfig": {
     "access": "public"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@
  * - Safe file path handling
  * - Connection validation with timeouts
  *
- * @module @thias-se/freshguard-core/cli
+ * @module @freshguard/freshguard-core/cli
  */
 
 import { readFile, writeFile, existsSync, mkdirSync } from 'fs';

--- a/src/connectors/bigquery.ts
+++ b/src/connectors/bigquery.ts
@@ -2,7 +2,7 @@
  * Secure BigQuery connector for FreshGuard Core
  * Extends BaseConnector with security built-in
  *
- * @module @thias-se/freshguard-core/connectors/bigquery
+ * @module @freshguard/freshguard-core/connectors/bigquery
  */
 
 import { BigQuery } from '@google-cloud/bigquery';

--- a/src/connectors/duckdb.ts
+++ b/src/connectors/duckdb.ts
@@ -2,7 +2,7 @@
  * Secure DuckDB connector for FreshGuard Core
  * Extends BaseConnector with security built-in
  *
- * @module @thias-se/freshguard-core/connectors/duckdb
+ * @module @freshguard/freshguard-core/connectors/duckdb
  */
 
 import type { DuckDBConnection } from '@duckdb/node-api';

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,6 +1,6 @@
 /**
  * Database connectors
- * @module @thias-se/freshguard-core/connectors
+ * @module @freshguard/freshguard-core/connectors
  */
 
 export { PostgresConnector } from './postgres.js';

--- a/src/connectors/mysql.ts
+++ b/src/connectors/mysql.ts
@@ -2,7 +2,7 @@
  * Secure MySQL connector for FreshGuard Core
  * Extends BaseConnector with security built-in
  *
- * @module @thias-se/freshguard-core/connectors/mysql
+ * @module @freshguard/freshguard-core/connectors/mysql
  */
 
 import mysql from 'mysql2/promise';

--- a/src/connectors/postgres.ts
+++ b/src/connectors/postgres.ts
@@ -2,7 +2,7 @@
  * Secure PostgreSQL connector for FreshGuard Core
  * Extends BaseConnector with security built-in
  *
- * @module @thias-se/freshguard-core/connectors/postgres
+ * @module @freshguard/freshguard-core/connectors/postgres
  */
 
 import postgres from 'postgres';

--- a/src/connectors/redshift.ts
+++ b/src/connectors/redshift.ts
@@ -3,7 +3,7 @@
  * Extends BaseConnector with security built-in
  * Uses PostgreSQL wire protocol for compatibility
  *
- * @module @thias-se/freshguard-core/connectors/redshift
+ * @module @freshguard/freshguard-core/connectors/redshift
  */
 
 import postgres from 'postgres';

--- a/src/connectors/snowflake.ts
+++ b/src/connectors/snowflake.ts
@@ -2,7 +2,7 @@
  * Secure Snowflake connector for FreshGuard Core
  * Extends BaseConnector with security built-in
  *
- * @module @thias-se/freshguard-core/connectors/snowflake
+ * @module @freshguard/freshguard-core/connectors/snowflake
  */
 
 import * as snowflake from 'snowflake-sdk';

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,6 @@
 /**
  * Database connection and schema exports
- * @module @thias-se/freshguard-core/db
+ * @module @freshguard/freshguard-core/db
  */
 
 import { drizzle } from 'drizzle-orm/postgres-js';

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,6 +1,6 @@
 /**
  * Database migration utilities for FreshGuard Core
- * @module @thias-se/freshguard-core/db/migrate
+ * @module @freshguard/freshguard-core/db/migrate
  */
 
 import { readFile, readdir } from 'fs/promises';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * FreshGuard Core - Open Source Data Pipeline Freshness Monitoring
  *
- * This is the public API for @thias-se/freshguard-core.
+ * This is the public API for @freshguard/freshguard-core.
  * Use this package to build self-hosted monitoring solutions.
  *
- * @module @thias-se/freshguard-core
+ * @module @freshguard/freshguard-core
  * @license MIT
  */
 

--- a/src/monitor/freshness.ts
+++ b/src/monitor/freshness.ts
@@ -8,7 +8,7 @@
  * - Timeout protection against long-running queries
  * - Safe parameter validation
  *
- * @module @thias-se/freshguard-core/monitor/freshness
+ * @module @freshguard/freshguard-core/monitor/freshness
  * @license MIT
  */
 

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,6 +1,6 @@
 /**
  * Monitoring logic exports
- * @module @thias-se/freshguard-core/monitor
+ * @module @freshguard/freshguard-core/monitor
  */
 
 export { checkFreshness } from './freshness.js';

--- a/src/monitor/schema-baseline.ts
+++ b/src/monitor/schema-baseline.ts
@@ -7,7 +7,7 @@
  * - Safe schema comparison algorithms
  * - Sanitized error messages
  *
- * @module @thias-se/freshguard-core/monitor/schema-baseline
+ * @module @freshguard/freshguard-core/monitor/schema-baseline
  * @license MIT
  */
 

--- a/src/monitor/schema-changes.ts
+++ b/src/monitor/schema-changes.ts
@@ -8,7 +8,7 @@
  * - Timeout protection against long-running queries
  * - Safe parameter validation
  *
- * @module @thias-se/freshguard-core/monitor/schema-changes
+ * @module @freshguard/freshguard-core/monitor/schema-changes
  * @license MIT
  */
 

--- a/src/monitor/volume.ts
+++ b/src/monitor/volume.ts
@@ -9,7 +9,7 @@
  * - Historical data access controls
  * - Statistical validation and overflow protection
  *
- * @module @thias-se/freshguard-core/monitor/volume
+ * @module @freshguard/freshguard-core/monitor/volume
  * @license MIT
  */
 


### PR DESCRIPTION
- Update npm package name from @thias-se/freshguard-core to @freshguard/freshguard-core
- Update GitHub repository URLs from thias-se to freshguard-dev
- Update all @module JSDoc references in source files
- Update documentation and examples with new package references
- Update GitHub workflow files for npm publishing

This is a breaking change for package name:
- Old: @thias-se/freshguard-core
- New: @freshguard/freshguard-core

https://claude.ai/code/session_01T6SpMMhLvAabz7viyv1pTL