### PR TITLE
fix: prevent verify-published job from hanging

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -483,9 +483,10 @@ jobs:
   verify-published:
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Wait for npm propagation
-        run: sleep 30
+        run: sleep 60
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -505,10 +506,10 @@ jobs:
           echo '{"name":"test-install","version":"1.0.0","type":"module"}' > package.json
 
           echo "Testing published packages..."
-          pnpm install @freshguard/freshguard-core@${{ needs.publish.outputs.version }}
+          pnpm install --ignore-scripts @freshguard/freshguard-core@${{ needs.publish.outputs.version }}
 
           node -e "
-            import('@freshguard/freshguard-core').then(({ checkFreshness, createDatabase, DataSourceType }) => {
+            import('@freshguard/freshguard-core').then(({ checkFreshness, createDatabase }) => {
               console.log('✅ Published package works correctly');
               console.log('✅ checkFreshness:', typeof checkFreshness);
               console.log('✅ createDatabase:', typeof createDatabase);


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to `pnpm install` in the `verify-published` job — native dependency postinstall scripts (duckdb, snowflake-sdk) were causing the install to hang indefinitely
- Add `timeout-minutes: 10` as a safety net so stuck jobs fail fast instead of running for hours
- Increase npm propagation wait from 30s to 60s for reliability
- Remove `DataSourceType` from the import test (it's a type-only export, doesn't exist at runtime)

## Context
Both the v0.13.1 and v0.13.2 publish runs got stuck on the "Test published packages" step — v0.13.1 ran for nearly 3 hours before being manually cancelled.

## Test plan
- [ ] Next tag push should complete the verify-published job within a few minutes instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)