### PR TITLE
feat: add SQL Server, Azure SQL, and Azure Synapse connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@freshguard/freshguard-core.svg)](https://www.npmjs.com/package/@freshguard/freshguard-core)
 [![Docs](https://img.shields.io/badge/docs-website-blue)](https://freshguard-dev.github.io/freshguard-core)
 
-Monitor when your data pipelines go stale. Supports PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, and Redshift. Self-hosted. Free forever.
+Monitor when your data pipelines go stale. Supports PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, Redshift, SQL Server, Azure SQL, and Azure Synapse. Self-hosted. Free forever.
 
 ## Install
 
@@ -75,6 +75,9 @@ if (result.status === 'alert') {
 | Snowflake | `SnowflakeConnector` | 0.2.0 |
 | MySQL | `MySQLConnector` | 0.11.0 |
 | Redshift | `RedshiftConnector` | 0.11.0 |
+| SQL Server | `MSSQLConnector` | 0.14.0 |
+| Azure SQL Database | `AzureSQLConnector` | 0.14.0 |
+| Azure Synapse Analytics | `SynapseConnector` | 0.14.0 |
 
 ## CLI
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,10 @@ FreshGuard Core is a layered monitoring engine. Data flows from user configurati
 │  ├── BigQueryConnector                           │
 │  ├── SnowflakeConnector                          │
 │  ├── MySQLConnector                              │
-│  └── RedshiftConnector                           │
+│  ├── RedshiftConnector                           │
+│  ├── MSSQLConnector                              │
+│  ├── AzureSQLConnector                           │
+│  └── SynapseConnector                            │
 │                                                  │
 │  Built-in: query validation, timeout protection, │
 │  error sanitization, structured logging          │
@@ -241,6 +244,7 @@ checkSchemaChanges(connector, rule, metadataStorage)
 | `@google-cloud/bigquery` | BigQuery connectivity |
 | `snowflake-sdk` | Snowflake connectivity |
 | `mysql2` | MySQL/MariaDB connectivity |
+| `mssql` | SQL Server, Azure SQL, and Azure Synapse connectivity |
 | `drizzle-orm` | Type-safe database schema and migrations |
 | `zod` | Runtime validation of configuration and inputs |
 | `pino` | Structured JSON logging |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,6 +64,9 @@ freshguard-core/
 │   │   ├── snowflake.ts     # Snowflake connector
 │   │   ├── mysql.ts         # MySQL connector
 │   │   ├── redshift.ts      # Redshift connector
+│   │   ├── mssql.ts         # SQL Server connector
+│   │   ├── azure-sql.ts     # Azure SQL Database connector
+│   │   ├── synapse.ts       # Azure Synapse Analytics connector
 │   │   └── index.ts         # Exports
 │   ├── monitor/             # Core algorithms
 │   │   ├── freshness.ts     # Freshness checking

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -6,7 +6,7 @@ Guide for self-hosting FreshGuard Core in your own environment.
 
 ✅ **Basic Security** - Input validation, SQL injection protection, secure connections
 ✅ **Core Monitoring** - Freshness, volume anomaly detection, and schema change monitoring
-✅ **Multi-Database Support** - PostgreSQL, BigQuery, Snowflake, DuckDB, MySQL, Redshift
+✅ **Multi-Database Support** - PostgreSQL, BigQuery, Snowflake, DuckDB, MySQL, Redshift, SQL Server, Azure SQL, Azure Synapse
 ✅ **Structured Logging** - JSON logging with error sanitization
 ✅ **Custom Integration** - Build your own alerting with the API
 ✅ **Full Control** - Your data stays on your infrastructure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshguard/freshguard-core",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
   "main": "./dist/index.js",
@@ -54,6 +54,7 @@
     "@duckdb/node-api": "1.4.4-r.1",
     "@google-cloud/bigquery": "^8.1.1",
     "drizzle-orm": "^0.45.1",
+    "mssql": "^11.0.0",
     "mysql2": "^3.16.3",
     "pg": "^8.18.0",
     "pino": "^10.3.1",
@@ -68,6 +69,7 @@
     "@types/eslint": "^9.6.1",
     "@types/extend": "^3.0.4",
     "@types/is": "^0.0.25",
+    "@types/mssql": "^9.1.9",
     "@types/pg": "^8.16.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@types/pg@8.16.0)(mysql2@3.16.3)(pg@8.18.0)(postgres@3.4.8)
+      mssql:
+        specifier: ^11.0.0
+        version: 11.0.1(@azure/core-client@1.10.1)
       mysql2:
         specifier: ^3.16.3
         version: 3.16.3
@@ -58,6 +61,9 @@ importers:
       '@types/is':
         specifier: ^0.0.25
         version: 0.0.25
+      '@types/mssql':
+        specifier: ^9.1.9
+        version: 9.1.9(@azure/core-client@1.10.1)
       '@types/pg':
         specifier: ^8.16.0
         version: 8.16.0
@@ -383,6 +389,10 @@ packages:
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
 
+  '@azure-rest/core-client@2.5.1':
+    resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
+    engines: {node: '>=20.0.0'}
+
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -429,6 +439,14 @@ packages:
   '@azure/identity@4.13.0':
     resolution: {integrity: sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==}
     engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-common@2.0.0':
+    resolution: {integrity: sha512-wRLVaroQtOqfg60cxkzUkGKrKMsCP6uYXAOomOIysSMyt1/YM0eUn9LqieAWM8DLcU4+07Fio2YGpPeqUbpP9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/keyvault-keys@4.10.0':
+    resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
+    engines: {node: '>=18.0.0'}
 
   '@azure/logger@1.3.0':
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
@@ -1865,6 +1883,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-joda/core@5.7.0':
+    resolution: {integrity: sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==}
+
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
     engines: {node: '>=10.0'}
@@ -2541,6 +2562,9 @@ packages:
   '@techteamer/ocsp@1.0.1':
     resolution: {integrity: sha512-q4pW5wAC6Pc3JI8UePwE37CkLQ5gDGZMgjSX4MEEm4D4Di59auDQ8UNIDzC4gRnPNmmcwjpPxozq8p5pjiOmOw==}
 
+  '@tediousjs/connection-string@0.5.0':
+    resolution: {integrity: sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ==}
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -2648,6 +2672,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mssql@9.1.9':
+    resolution: {integrity: sha512-P0nCgw6vzY23UxZMnbI4N7fnLGANt4LI4yvxze1paPj+LuN28cFv5EI+QidP8udnId/BKhkcRhm/BleNsjK65A==}
+
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
@@ -2680,6 +2707,9 @@ packages:
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
+
+  '@types/readable-stream@4.0.23':
+    resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
 
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
@@ -3130,6 +3160,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bl@6.1.6:
+    resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
+
   bn.js@4.12.2:
     resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
 
@@ -3181,6 +3214,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3359,6 +3395,10 @@ packages:
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -4546,6 +4586,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -4555,6 +4599,9 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4784,6 +4831,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-md4@0.3.2:
+    resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -5296,6 +5346,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mssql@11.0.1:
+    resolution: {integrity: sha512-KlGNsugoT90enKlR8/G36H0kTxPthDhmtNUCwEHvgRza5Cjpjoj+P2X6eMpFUDN7pFrJZsKadL4x990G8RBE1w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
@@ -5312,6 +5367,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  native-duplexpair@1.0.0:
+    resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -6074,6 +6132,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -6199,6 +6261,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -6344,6 +6410,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@6.1.2:
     resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
@@ -6577,6 +6646,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
@@ -6698,6 +6770,14 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
+  tedious@18.6.2:
+    resolution: {integrity: sha512-g7jC56o3MzLkE3lHkaFe2ZdOVFBahq5bsB60/M4NYUbocw/MCrS89IOEQUFr+ba6pb8ZHczZ/VqCyYeYq0xBAg==}
+    engines: {node: '>=18'}
 
   teeny-request@10.1.0:
     resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
@@ -7916,6 +7996,17 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.3': {}
 
+  '@azure-rest/core-client@2.5.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@typespec/ts-http-runtime': 0.3.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@azure/abort-controller@2.1.2':
     dependencies:
       tslib: 2.8.1
@@ -8002,6 +8093,37 @@ snapshots:
       open: 10.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-common@2.0.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.5.1
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.3.2(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.22.2)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.22.2
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/keyvault-common': 2.0.0
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
       - supports-color
 
   '@azure/logger@1.3.0':
@@ -10177,6 +10299,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-joda/core@5.7.0': {}
+
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
@@ -11037,6 +11161,8 @@ snapshots:
       async: 3.2.6
       simple-lru-cache: 0.0.2
 
+  '@tediousjs/connection-string@0.5.0': {}
+
   '@tootallnate/once@2.0.0': {}
 
   '@trysound/sax@0.2.0': {}
@@ -11152,6 +11278,15 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mssql@9.1.9(@azure/core-client@1.10.1)':
+    dependencies:
+      '@types/node': 25.2.3
+      tarn: 3.0.2
+      tedious: 18.6.2(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
   '@types/node@17.0.45': {}
 
   '@types/node@25.2.2':
@@ -11194,6 +11329,10 @@ snapshots:
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
+
+  '@types/readable-stream@4.0.23':
+    dependencies:
+      '@types/node': 25.2.3
 
   '@types/request@2.48.13':
     dependencies:
@@ -11735,6 +11874,13 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bl@6.1.6:
+    dependencies:
+      '@types/readable-stream': 4.0.23
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 4.7.0
+
   bn.js@4.12.2: {}
 
   bn.js@5.2.2: {}
@@ -11813,6 +11959,11 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -11987,6 +12138,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
+
+  commander@11.1.0: {}
 
   commander@2.20.3: {}
 
@@ -13324,6 +13477,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -13331,6 +13488,8 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -13508,6 +13667,8 @@ snapshots:
 
   joycon@3.1.1:
     optional: true
+
+  js-md4@0.3.2: {}
 
   js-tokens@10.0.0: {}
 
@@ -14295,6 +14456,18 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mssql@11.0.1(@azure/core-client@1.10.1):
+    dependencies:
+      '@tediousjs/connection-string': 0.5.0
+      commander: 11.1.0
+      debug: 4.4.3
+      rfdc: 1.4.1
+      tarn: 3.0.2
+      tedious: 18.6.2(@azure/core-client@1.10.1)
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
@@ -14317,6 +14490,8 @@ snapshots:
       lru.min: 1.1.4
 
   nanoid@3.3.11: {}
+
+  native-duplexpair@1.0.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -15130,6 +15305,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  process@0.11.10: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -15273,6 +15450,14 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   readdirp@3.6.0:
     dependencies:
@@ -15479,6 +15664,8 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@6.1.2:
     dependencies:
@@ -15823,6 +16010,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3: {}
+
   sqlstring@2.3.3: {}
 
   srcset@4.0.0: {}
@@ -15934,6 +16123,24 @@ snapshots:
       picocolors: 1.1.1
 
   tapable@2.3.0: {}
+
+  tarn@3.0.2: {}
+
+  tedious@18.6.2(@azure/core-client@1.10.1):
+    dependencies:
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.0
+      '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
+      '@js-joda/core': 5.7.0
+      '@types/node': 25.2.3
+      bl: 6.1.6
+      iconv-lite: 0.6.3
+      js-md4: 0.3.2
+      native-duplexpair: 1.0.0
+      sprintf-js: 1.1.3
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
 
   teeny-request@10.1.0:
     dependencies:

--- a/src/connectors/azure-sql.ts
+++ b/src/connectors/azure-sql.ts
@@ -1,0 +1,575 @@
+/**
+ * Secure Azure SQL Database connector for FreshGuard Core
+ * Extends BaseConnector with security built-in
+ * Uses mssql driver with Azure-specific connection configuration
+ *
+ * @module @freshguard/freshguard-core/connectors/azure-sql
+ */
+
+import * as mssql from 'mssql';
+import { BaseConnector } from './base-connector.js';
+import type { ConnectorConfig, TableSchema, SecurityConfig } from '../types/connector.js';
+import { type QueryResultRow, rowString } from '../types/driver-results.js';
+import type { SourceCredentials } from '../types.js';
+import {
+  ConnectionError,
+  TimeoutError,
+  QueryError,
+  ErrorHandler
+} from '../errors/index.js';
+import { validateConnectorConfig } from '../validators/index.js';
+
+/**
+ * Secure Azure SQL Database connector
+ *
+ * Features:
+ * - SQL injection prevention
+ * - Connection timeouts
+ * - SSL always enforced (Azure requirement)
+ * - Azure AD token-based authentication support
+ * - Read-only query patterns
+ * - Secure error handling
+ */
+export class AzureSQLConnector extends BaseConnector {
+  private pool: mssql.ConnectionPool | null = null;
+  private connected = false;
+
+  constructor(config: ConnectorConfig, securityConfig?: Partial<SecurityConfig>) {
+    // Validate configuration before proceeding
+    validateConnectorConfig(config);
+    super(config, securityConfig);
+  }
+
+  /**
+   * Connect to Azure SQL Database with security validation
+   */
+  private async connect(): Promise<void> {
+    if (this.connected && this.pool) {
+      return; // Already connected
+    }
+
+    try {
+      const poolConfig: mssql.config = {
+        server: this.config.host,
+        port: this.config.port ?? 1433,
+        database: this.config.database,
+        user: this.config.username,
+        password: this.config.password,
+        options: {
+          // Azure SQL always requires encryption
+          encrypt: true,
+          trustServerCertificate: false,
+          connectTimeout: this.connectionTimeout,
+          requestTimeout: this.queryTimeout,
+          appName: this.config.applicationName ?? 'freshguard-core'
+        },
+        pool: {
+          max: 1, // Single connection for monitoring
+          min: 0,
+          idleTimeoutMillis: 30000
+        }
+      };
+
+      this.pool = new mssql.ConnectionPool(poolConfig);
+      await this.pool.connect();
+
+      this.connected = true;
+    } catch (error) {
+      throw new ConnectionError(
+        'Failed to connect to Azure SQL Database',
+        this.config.host,
+        this.config.port,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Execute a validated SQL query with security measures
+   */
+  protected async executeQuery(sql: string): Promise<QueryResultRow[]> {
+    return this.executeParameterizedQuery(sql, []);
+  }
+
+  /**
+   * Execute a parameterized SQL query using prepared statements
+   */
+  protected async executeParameterizedQuery(sql: string, parameters: unknown[] = []): Promise<QueryResultRow[]> {
+    await this.connect();
+
+    if (!this.pool) {
+      throw new ConnectionError('Database connection not available');
+    }
+
+    try {
+      const result = await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+
+          // Bind positional parameters as @p1, @p2, etc.
+          for (let i = 0; i < parameters.length; i++) {
+            request.input(`p${i + 1}`, parameters[i]);
+          }
+
+          // Replace $N placeholders with @pN for MSSQL
+          let mssqlSql = sql;
+          for (let i = parameters.length; i >= 1; i--) {
+            mssqlSql = mssqlSql.replace(new RegExp(`\\$${i}`, 'g'), `@p${i}`);
+          }
+          // Also replace ? placeholders with @pN
+          let paramIndex = 0;
+          mssqlSql = mssqlSql.replace(/\?/g, () => `@p${++paramIndex}`);
+
+          const res = await request.query(mssqlSql);
+          return (res.recordset ?? []) as Record<string, unknown>[];
+        },
+        this.queryTimeout
+      );
+
+      // Validate result size for security
+      this.validateResultSize(result);
+
+      return result;
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        throw error;
+      }
+
+      // Sanitize and re-throw as QueryError
+      throw new QueryError(
+        ErrorHandler.getUserMessage(error),
+        'query_execution',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Test database connection with security validation
+   */
+  async testConnection(debugConfig?: import('../types.js').DebugConfig): Promise<boolean> {
+    const mergedDebugConfig = this.mergeDebugConfig(debugConfig);
+    const debugId = `azuresql-test-${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 5)}`;
+    const startTime = performance.now();
+
+    try {
+      this.logDebugInfo(mergedDebugConfig, debugId, 'Starting connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        ssl: this.config.ssl
+      });
+
+      await this.connect();
+
+      if (!this.pool) {
+        this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+          error: 'Connection not available after connect',
+          duration: performance.now() - startTime
+        });
+        return false;
+      }
+
+      // Test with a simple, safe query (skip validation for connection test)
+      const sql = 'SELECT 1 AS test';
+
+      await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+          return request.query(sql);
+        },
+        this.connectionTimeout
+      );
+
+      const duration = performance.now() - startTime;
+
+      if (mergedDebugConfig?.enabled) {
+        console.log(`[DEBUG-${debugId}] Connection test completed:`, {
+          success: true,
+          duration,
+          host: this.config.host,
+          database: this.config.database
+        });
+      }
+
+      return true;
+    } catch (error) {
+      const duration = performance.now() - startTime;
+
+      this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        error: mergedDebugConfig?.exposeRawErrors && error instanceof Error ? error.message : 'Connection failed',
+        duration,
+        suggestion: this.generateConnectionSuggestion(error)
+      });
+
+      // Don't throw - this method should return boolean
+      return false;
+    }
+  }
+
+  /**
+   * Helper method to merge debug configuration
+   */
+  private mergeDebugConfig(debugConfig?: import('../types.js').DebugConfig): import('../types.js').DebugConfig {
+    return {
+      enabled: debugConfig?.enabled ?? (process.env.NODE_ENV === 'development'),
+      exposeQueries: debugConfig?.exposeQueries ?? true,
+      exposeRawErrors: debugConfig?.exposeRawErrors ?? true,
+      logLevel: debugConfig?.logLevel ?? 'debug'
+    };
+  }
+
+  /**
+   * Generate connection suggestions based on error (Azure-specific)
+   */
+  private generateConnectionSuggestion(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return 'Check database connection configuration';
+    }
+
+    const message = error.message.toLowerCase();
+
+    if (message.includes('connect econnrefused') || message.includes('connection refused')) {
+      return `Azure SQL Database at ${this.config.host}:${this.config.port} is not accepting connections. Verify the server name and check Azure SQL firewall rules.`;
+    }
+
+    if (message.includes('timeout') || message.includes('connect timeout')) {
+      return `Connection timeout to ${this.config.host}:${this.config.port}. Check Azure SQL firewall rules, network connectivity, and ensure your IP is allowed.`;
+    }
+
+    if (message.includes('login failed') || message.includes('authentication failed')) {
+      return `Authentication failed for database '${this.config.database}'. Verify username, password, and Azure AD configuration if using AAD auth.`;
+    }
+
+    if (message.includes('cannot open database') || (message.includes('database') && message.includes('not exist'))) {
+      return `Database '${this.config.database}' not found. Check database name on your Azure SQL server.`;
+    }
+
+    if (message.includes('ssl') || message.includes('tls') || message.includes('encrypt')) {
+      return `SSL/TLS connection issue. Azure SQL requires encryption - check SSL certificate configuration.`;
+    }
+
+    if (message.includes('firewall')) {
+      return `Connection blocked by Azure SQL firewall. Add your client IP address to the server's firewall rules in the Azure portal.`;
+    }
+
+    if (message.includes('azure active directory') || message.includes('aad')) {
+      return `Azure AD authentication issue. Verify Azure AD admin is configured and the user has proper permissions.`;
+    }
+
+    return `Connection failed to ${this.config.host}:${this.config.port}. Check host, port, credentials, firewall rules, and network connectivity.`;
+  }
+
+  /**
+   * List all tables in the database
+   */
+  async listTables(): Promise<string[]> {
+    const sql = `
+      SELECT TABLE_NAME as table_name
+      FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_TYPE = 'BASE TABLE'
+        AND TABLE_SCHEMA = 'dbo'
+      ORDER BY TABLE_NAME
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      return result
+        .slice(0, this.maxRows)
+        .map((row) => rowString(row.table_name ?? row.TABLE_NAME ?? row.tablename))
+        .filter(Boolean);
+    } catch (error) {
+      throw new QueryError(
+        'Failed to list tables',
+        'table_listing',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get table schema information securely
+   */
+  async getTableSchema(table: string): Promise<TableSchema> {
+    // Validate table name (identifiers cannot be parameterized)
+    this.escapeIdentifier(table);
+
+    const sql = `
+      SELECT
+        COLUMN_NAME as column_name,
+        DATA_TYPE as data_type,
+        IS_NULLABLE as is_nullable
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = 'dbo'
+        AND TABLE_NAME = '${table}'
+      ORDER BY ORDINAL_POSITION
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      const limited = result.slice(0, this.maxRows);
+
+      if (limited.length === 0) {
+        throw QueryError.tableNotFound(table);
+      }
+
+      return {
+        table,
+        columns: limited.map(row => ({
+          name: rowString(row.column_name ?? row.COLUMN_NAME),
+          type: this.mapMSSQLType(rowString(row.data_type ?? row.DATA_TYPE)),
+          nullable: (row.is_nullable ?? row.IS_NULLABLE) === 'YES'
+        }))
+      };
+    } catch (error) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      throw new QueryError(
+        'Failed to get table schema',
+        'schema_query',
+        table,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get last modified timestamp using SQL Server-specific methods
+   */
+  async getLastModified(table: string): Promise<Date | null> {
+    // Try common timestamp columns
+    const timestampColumns = ['updated_at', 'modified_at', 'last_modified', 'timestamp'];
+
+    for (const column of timestampColumns) {
+      try {
+        const result = await this.getMaxTimestamp(table, column);
+        if (result) {
+          return result;
+        }
+      } catch {
+        // Column doesn't exist, try next one
+        continue;
+      }
+    }
+
+    // Fallback: use SQL Server DMV for index usage stats
+    try {
+      const sql = `
+        SELECT MAX(last_user_update) as last_modified
+        FROM sys.dm_db_index_usage_stats
+        WHERE database_id = DB_ID()
+          AND object_id = OBJECT_ID('dbo.${this.escapeIdentifier(table).replace(/\[|\]/g, '')}')
+      `;
+
+      await this.validateQuery(sql);
+      const result = await this.executeQuery(sql);
+
+      if (result.length > 0 && result[0]?.last_modified) {
+        return new Date(rowString(result[0].last_modified));
+      }
+    } catch {
+      // DMV query failed, return null
+    }
+
+    return null;
+  }
+
+  /**
+   * Close the database connection
+   */
+  async close(): Promise<void> {
+    if (this.pool) {
+      try {
+        await this.pool.close();
+      } catch (error) {
+        // Log error but don't throw - closing should be safe
+        console.warn('Warning: Error closing Azure SQL connection:', ErrorHandler.getUserMessage(error));
+      } finally {
+        this.pool = null;
+        this.connected = false;
+      }
+    }
+  }
+
+  /**
+   * Map SQL Server/Azure SQL data types to standard types
+   */
+  private mapMSSQLType(mssqlType: string): string {
+    const typeMap: Record<string, string> = {
+      // Numeric types
+      'tinyint': 'integer',
+      'smallint': 'integer',
+      'int': 'integer',
+      'integer': 'integer',
+      'bigint': 'bigint',
+      'decimal': 'decimal',
+      'numeric': 'decimal',
+      'money': 'decimal',
+      'smallmoney': 'decimal',
+      'float': 'float',
+      'real': 'float',
+      'bit': 'boolean',
+
+      // String types
+      'char': 'text',
+      'varchar': 'text',
+      'text': 'text',
+      'nchar': 'text',
+      'nvarchar': 'text',
+      'ntext': 'text',
+
+      // Date/time types
+      'date': 'date',
+      'time': 'time',
+      'datetime': 'timestamp',
+      'datetime2': 'timestamp',
+      'smalldatetime': 'timestamp',
+      'datetimeoffset': 'timestamptz',
+
+      // Binary types
+      'binary': 'text',
+      'varbinary': 'text',
+      'image': 'text',
+
+      // Special types
+      'uniqueidentifier': 'text',
+      'xml': 'text',
+      'sql_variant': 'text',
+      'hierarchyid': 'text',
+      'geometry': 'text',
+      'geography': 'text',
+      'timestamp': 'text',
+      'rowversion': 'text'
+    };
+
+    return typeMap[mssqlType.toLowerCase()] ?? 'unknown';
+  }
+
+  /**
+   * Override escapeIdentifier for SQL Server bracket notation
+   */
+  protected escapeIdentifier(identifier: string): string {
+    // Only allow alphanumeric, underscore, and dot (for schema.table)
+    if (!/^[a-zA-Z0-9_.]+$/.test(identifier)) {
+      throw new Error(`Invalid identifier: ${identifier}`);
+    }
+
+    // Additional length check
+    if (identifier.length > 256) {
+      throw new Error('Identifier too long');
+    }
+
+    // Return with brackets for SQL Server
+    return `[${identifier}]`;
+  }
+
+  // ==============================================
+  // Legacy API compatibility methods
+  // ==============================================
+
+  /**
+   * Legacy connect method for backward compatibility
+   * @deprecated Use constructor with ConnectorConfig instead
+   */
+  async connectLegacy(credentials: SourceCredentials): Promise<void> {
+    console.warn('Warning: connectLegacy is deprecated. Use constructor with ConnectorConfig instead.');
+
+    // Convert legacy credentials to new format
+    const config: ConnectorConfig = {
+      host: credentials.host ?? '',
+      port: credentials.port ?? 1433,
+      database: credentials.database ?? '',
+      username: credentials.username ?? '',
+      password: credentials.password ?? '',
+      ssl: credentials.sslMode !== 'disable'
+    };
+
+    // Validate and reconnect
+    validateConnectorConfig(config);
+    this.config = { ...this.config, ...config };
+    await this.connect();
+  }
+
+  /**
+   * Legacy test connection method for backward compatibility
+   * @deprecated Use testConnection() instead
+   */
+  async testConnectionLegacy(): Promise<{ success: boolean; tableCount?: number; error?: string }> {
+    console.warn('Warning: testConnectionLegacy is deprecated. Use testConnection() instead.');
+
+    try {
+      const success = await this.testConnection();
+
+      if (success) {
+        // Get table count for legacy compatibility
+        const tables = await this.listTables();
+        return {
+          success: true,
+          tableCount: tables.length
+        };
+      } else {
+        return {
+          success: false,
+          error: 'Connection test failed'
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: ErrorHandler.getUserMessage(error)
+      };
+    }
+  }
+
+  /**
+   * Legacy get table metadata method for backward compatibility
+   * @deprecated Use getRowCount() and getMaxTimestamp() instead
+   */
+  async getTableMetadata(
+    tableName: string,
+    timestampColumn = 'updated_at'
+  ): Promise<{ rowCount: number; lastUpdate?: Date }> {
+    console.warn('Warning: getTableMetadata is deprecated. Use getRowCount() and getMaxTimestamp() instead.');
+
+    try {
+      const rowCount = await this.getRowCount(tableName);
+      const lastUpdate = await this.getMaxTimestamp(tableName, timestampColumn);
+
+      return {
+        rowCount,
+        lastUpdate: lastUpdate ?? undefined
+      };
+    } catch (error) {
+      throw new QueryError(
+        'Failed to get table metadata',
+        'metadata_query',
+        tableName,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Legacy query method for backward compatibility
+   * @deprecated Direct SQL queries are not allowed for security reasons
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await -- deprecated stub that always throws
+  async query<T = unknown>(_sql: string): Promise<T[]> {
+    throw new Error(
+      'Direct SQL queries are not allowed for security reasons. Use specific methods like getRowCount(), getMaxTimestamp(), etc.'
+    );
+  }
+}

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -9,3 +9,6 @@ export { BigQueryConnector } from './bigquery.js';
 export { SnowflakeConnector } from './snowflake.js';
 export { MySQLConnector } from './mysql.js';
 export { RedshiftConnector } from './redshift.js';
+export { MSSQLConnector } from './mssql.js';
+export { AzureSQLConnector } from './azure-sql.js';
+export { SynapseConnector } from './synapse.js';

--- a/src/connectors/mssql.ts
+++ b/src/connectors/mssql.ts
@@ -1,0 +1,569 @@
+/**
+ * Secure Microsoft SQL Server connector for FreshGuard Core
+ * Extends BaseConnector with security built-in
+ *
+ * @module @freshguard/freshguard-core/connectors/mssql
+ */
+
+import * as mssql from 'mssql';
+import { BaseConnector } from './base-connector.js';
+import type { ConnectorConfig, TableSchema, SecurityConfig } from '../types/connector.js';
+import { type QueryResultRow, rowString } from '../types/driver-results.js';
+import type { SourceCredentials } from '../types.js';
+import {
+  ConnectionError,
+  TimeoutError,
+  QueryError,
+  ErrorHandler
+} from '../errors/index.js';
+import { validateConnectorConfig } from '../validators/index.js';
+
+/**
+ * Secure SQL Server connector
+ *
+ * Features:
+ * - SQL injection prevention
+ * - Connection timeouts
+ * - SSL enforcement
+ * - Read-only query patterns
+ * - Secure error handling
+ * - Connection pooling via mssql
+ */
+export class MSSQLConnector extends BaseConnector {
+  private pool: mssql.ConnectionPool | null = null;
+  private connected = false;
+
+  constructor(config: ConnectorConfig, securityConfig?: Partial<SecurityConfig>) {
+    // Validate configuration before proceeding
+    validateConnectorConfig(config);
+    super(config, securityConfig);
+  }
+
+  /**
+   * Connect to SQL Server database with security validation
+   */
+  private async connect(): Promise<void> {
+    if (this.connected && this.pool) {
+      return; // Already connected
+    }
+
+    try {
+      const poolConfig: mssql.config = {
+        server: this.config.host,
+        port: this.config.port ?? 1433,
+        database: this.config.database,
+        user: this.config.username,
+        password: this.config.password,
+        options: {
+          encrypt: this.requireSSL || this.config.ssl !== false,
+          trustServerCertificate: false,
+          connectTimeout: this.connectionTimeout,
+          requestTimeout: this.queryTimeout,
+          appName: this.config.applicationName ?? 'freshguard-core'
+        },
+        pool: {
+          max: 1, // Single connection for monitoring
+          min: 0,
+          idleTimeoutMillis: 30000
+        }
+      };
+
+      this.pool = new mssql.ConnectionPool(poolConfig);
+      await this.pool.connect();
+
+      this.connected = true;
+    } catch (error) {
+      throw new ConnectionError(
+        'Failed to connect to SQL Server',
+        this.config.host,
+        this.config.port,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Execute a validated SQL query with security measures
+   */
+  protected async executeQuery(sql: string): Promise<QueryResultRow[]> {
+    return this.executeParameterizedQuery(sql, []);
+  }
+
+  /**
+   * Execute a parameterized SQL query using prepared statements
+   */
+  protected async executeParameterizedQuery(sql: string, parameters: unknown[] = []): Promise<QueryResultRow[]> {
+    await this.connect();
+
+    if (!this.pool) {
+      throw new ConnectionError('Database connection not available');
+    }
+
+    try {
+      const result = await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+
+          // Bind positional parameters as @p1, @p2, etc.
+          for (let i = 0; i < parameters.length; i++) {
+            request.input(`p${i + 1}`, parameters[i]);
+          }
+
+          // Replace $N placeholders with @pN for MSSQL
+          let mssqlSql = sql;
+          for (let i = parameters.length; i >= 1; i--) {
+            mssqlSql = mssqlSql.replace(new RegExp(`\\$${i}`, 'g'), `@p${i}`);
+          }
+          // Also replace ? placeholders with @pN
+          let paramIndex = 0;
+          mssqlSql = mssqlSql.replace(/\?/g, () => `@p${++paramIndex}`);
+
+          const res = await request.query(mssqlSql);
+          return (res.recordset ?? []) as Record<string, unknown>[];
+        },
+        this.queryTimeout
+      );
+
+      // Validate result size for security
+      this.validateResultSize(result);
+
+      return result;
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        throw error;
+      }
+
+      // Sanitize and re-throw as QueryError
+      throw new QueryError(
+        ErrorHandler.getUserMessage(error),
+        'query_execution',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Test database connection with security validation
+   */
+  async testConnection(debugConfig?: import('../types.js').DebugConfig): Promise<boolean> {
+    const mergedDebugConfig = this.mergeDebugConfig(debugConfig);
+    const debugId = `mssql-test-${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 5)}`;
+    const startTime = performance.now();
+
+    try {
+      this.logDebugInfo(mergedDebugConfig, debugId, 'Starting connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        ssl: this.config.ssl
+      });
+
+      await this.connect();
+
+      if (!this.pool) {
+        this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+          error: 'Connection not available after connect',
+          duration: performance.now() - startTime
+        });
+        return false;
+      }
+
+      // Test with a simple, safe query (skip validation for connection test)
+      const sql = 'SELECT 1 AS test';
+
+      await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+          return request.query(sql);
+        },
+        this.connectionTimeout
+      );
+
+      const duration = performance.now() - startTime;
+
+      if (mergedDebugConfig?.enabled) {
+        console.log(`[DEBUG-${debugId}] Connection test completed:`, {
+          success: true,
+          duration,
+          host: this.config.host,
+          database: this.config.database
+        });
+      }
+
+      return true;
+    } catch (error) {
+      const duration = performance.now() - startTime;
+
+      this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        error: mergedDebugConfig?.exposeRawErrors && error instanceof Error ? error.message : 'Connection failed',
+        duration,
+        suggestion: this.generateConnectionSuggestion(error)
+      });
+
+      // Don't throw - this method should return boolean
+      return false;
+    }
+  }
+
+  /**
+   * Helper method to merge debug configuration
+   */
+  private mergeDebugConfig(debugConfig?: import('../types.js').DebugConfig): import('../types.js').DebugConfig {
+    return {
+      enabled: debugConfig?.enabled ?? (process.env.NODE_ENV === 'development'),
+      exposeQueries: debugConfig?.exposeQueries ?? true,
+      exposeRawErrors: debugConfig?.exposeRawErrors ?? true,
+      logLevel: debugConfig?.logLevel ?? 'debug'
+    };
+  }
+
+  /**
+   * Generate connection suggestions based on error
+   */
+  private generateConnectionSuggestion(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return 'Check database connection configuration';
+    }
+
+    const message = error.message.toLowerCase();
+
+    if (message.includes('connect econnrefused') || message.includes('connection refused')) {
+      return `SQL Server at ${this.config.host}:${this.config.port} is not accepting connections. Verify the server is running and TCP/IP protocol is enabled in SQL Server Configuration Manager.`;
+    }
+
+    if (message.includes('timeout') || message.includes('connect timeout')) {
+      return `Connection timeout to ${this.config.host}:${this.config.port}. Check network connectivity, firewall rules, and server responsiveness.`;
+    }
+
+    if (message.includes('login failed') || message.includes('authentication failed')) {
+      return `Authentication failed for database '${this.config.database}'. Verify username, password, and that SQL Server authentication is enabled.`;
+    }
+
+    if (message.includes('cannot open database') || message.includes('database') && message.includes('not exist')) {
+      return `Database '${this.config.database}' not found on server. Check database name and create if necessary.`;
+    }
+
+    if (message.includes('ssl') || message.includes('tls') || message.includes('encrypt')) {
+      return `SSL/TLS connection issue. Check SSL configuration and server certificate settings.`;
+    }
+
+    if (message.includes('named pipes') || message.includes('named instance')) {
+      return `Connection issue with named instance. Ensure SQL Server Browser service is running and use hostname\\instance format.`;
+    }
+
+    return `Connection failed to ${this.config.host}:${this.config.port}. Check host, port, credentials, and network connectivity.`;
+  }
+
+  /**
+   * List all tables in the database
+   */
+  async listTables(): Promise<string[]> {
+    const sql = `
+      SELECT TABLE_NAME as table_name
+      FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_TYPE = 'BASE TABLE'
+        AND TABLE_SCHEMA = 'dbo'
+      ORDER BY TABLE_NAME
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      return result
+        .slice(0, this.maxRows)
+        .map((row) => rowString(row.table_name ?? row.TABLE_NAME ?? row.tablename))
+        .filter(Boolean);
+    } catch (error) {
+      throw new QueryError(
+        'Failed to list tables',
+        'table_listing',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get table schema information securely
+   */
+  async getTableSchema(table: string): Promise<TableSchema> {
+    // Validate table name (identifiers cannot be parameterized)
+    this.escapeIdentifier(table);
+
+    const sql = `
+      SELECT
+        COLUMN_NAME as column_name,
+        DATA_TYPE as data_type,
+        IS_NULLABLE as is_nullable
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = 'dbo'
+        AND TABLE_NAME = '${table}'
+      ORDER BY ORDINAL_POSITION
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      const limited = result.slice(0, this.maxRows);
+
+      if (limited.length === 0) {
+        throw QueryError.tableNotFound(table);
+      }
+
+      return {
+        table,
+        columns: limited.map(row => ({
+          name: rowString(row.column_name ?? row.COLUMN_NAME),
+          type: this.mapMSSQLType(rowString(row.data_type ?? row.DATA_TYPE)),
+          nullable: (row.is_nullable ?? row.IS_NULLABLE) === 'YES'
+        }))
+      };
+    } catch (error) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      throw new QueryError(
+        'Failed to get table schema',
+        'schema_query',
+        table,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get last modified timestamp using SQL Server-specific methods
+   */
+  async getLastModified(table: string): Promise<Date | null> {
+    // Try common timestamp columns
+    const timestampColumns = ['updated_at', 'modified_at', 'last_modified', 'timestamp'];
+
+    for (const column of timestampColumns) {
+      try {
+        const result = await this.getMaxTimestamp(table, column);
+        if (result) {
+          return result;
+        }
+      } catch {
+        // Column doesn't exist, try next one
+        continue;
+      }
+    }
+
+    // Fallback: use SQL Server DMV for index usage stats
+    try {
+      const sql = `
+        SELECT MAX(last_user_update) as last_modified
+        FROM sys.dm_db_index_usage_stats
+        WHERE database_id = DB_ID()
+          AND object_id = OBJECT_ID('dbo.${this.escapeIdentifier(table).replace(/\[|\]/g, '')}')
+      `;
+
+      await this.validateQuery(sql);
+      const result = await this.executeQuery(sql);
+
+      if (result.length > 0 && result[0]?.last_modified) {
+        return new Date(rowString(result[0].last_modified));
+      }
+    } catch {
+      // DMV query failed, return null
+    }
+
+    return null;
+  }
+
+  /**
+   * Close the database connection
+   */
+  async close(): Promise<void> {
+    if (this.pool) {
+      try {
+        await this.pool.close();
+      } catch (error) {
+        // Log error but don't throw - closing should be safe
+        console.warn('Warning: Error closing SQL Server connection:', ErrorHandler.getUserMessage(error));
+      } finally {
+        this.pool = null;
+        this.connected = false;
+      }
+    }
+  }
+
+  /**
+   * Map SQL Server data types to standard types
+   */
+  private mapMSSQLType(mssqlType: string): string {
+    const typeMap: Record<string, string> = {
+      // Numeric types
+      'tinyint': 'integer',
+      'smallint': 'integer',
+      'int': 'integer',
+      'integer': 'integer',
+      'bigint': 'bigint',
+      'decimal': 'decimal',
+      'numeric': 'decimal',
+      'money': 'decimal',
+      'smallmoney': 'decimal',
+      'float': 'float',
+      'real': 'float',
+      'bit': 'boolean',
+
+      // String types
+      'char': 'text',
+      'varchar': 'text',
+      'text': 'text',
+      'nchar': 'text',
+      'nvarchar': 'text',
+      'ntext': 'text',
+
+      // Date/time types
+      'date': 'date',
+      'time': 'time',
+      'datetime': 'timestamp',
+      'datetime2': 'timestamp',
+      'smalldatetime': 'timestamp',
+      'datetimeoffset': 'timestamptz',
+
+      // Binary types
+      'binary': 'text',
+      'varbinary': 'text',
+      'image': 'text',
+
+      // Special types
+      'uniqueidentifier': 'text',
+      'xml': 'text',
+      'sql_variant': 'text',
+      'hierarchyid': 'text',
+      'geometry': 'text',
+      'geography': 'text',
+      'timestamp': 'text', // SQL Server timestamp is a rowversion, not a date
+      'rowversion': 'text'
+    };
+
+    return typeMap[mssqlType.toLowerCase()] ?? 'unknown';
+  }
+
+  /**
+   * Override escapeIdentifier for SQL Server bracket notation
+   */
+  protected escapeIdentifier(identifier: string): string {
+    // Only allow alphanumeric, underscore, and dot (for schema.table)
+    if (!/^[a-zA-Z0-9_.]+$/.test(identifier)) {
+      throw new Error(`Invalid identifier: ${identifier}`);
+    }
+
+    // Additional length check
+    if (identifier.length > 256) {
+      throw new Error('Identifier too long');
+    }
+
+    // Return with brackets for SQL Server
+    return `[${identifier}]`;
+  }
+
+  // ==============================================
+  // Legacy API compatibility methods
+  // ==============================================
+
+  /**
+   * Legacy connect method for backward compatibility
+   * @deprecated Use constructor with ConnectorConfig instead
+   */
+  async connectLegacy(credentials: SourceCredentials): Promise<void> {
+    console.warn('Warning: connectLegacy is deprecated. Use constructor with ConnectorConfig instead.');
+
+    // Convert legacy credentials to new format
+    const config: ConnectorConfig = {
+      host: credentials.host ?? '',
+      port: credentials.port ?? 1433,
+      database: credentials.database ?? '',
+      username: credentials.username ?? '',
+      password: credentials.password ?? '',
+      ssl: credentials.sslMode !== 'disable'
+    };
+
+    // Validate and reconnect
+    validateConnectorConfig(config);
+    this.config = { ...this.config, ...config };
+    await this.connect();
+  }
+
+  /**
+   * Legacy test connection method for backward compatibility
+   * @deprecated Use testConnection() instead
+   */
+  async testConnectionLegacy(): Promise<{ success: boolean; tableCount?: number; error?: string }> {
+    console.warn('Warning: testConnectionLegacy is deprecated. Use testConnection() instead.');
+
+    try {
+      const success = await this.testConnection();
+
+      if (success) {
+        // Get table count for legacy compatibility
+        const tables = await this.listTables();
+        return {
+          success: true,
+          tableCount: tables.length
+        };
+      } else {
+        return {
+          success: false,
+          error: 'Connection test failed'
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: ErrorHandler.getUserMessage(error)
+      };
+    }
+  }
+
+  /**
+   * Legacy get table metadata method for backward compatibility
+   * @deprecated Use getRowCount() and getMaxTimestamp() instead
+   */
+  async getTableMetadata(
+    tableName: string,
+    timestampColumn = 'updated_at'
+  ): Promise<{ rowCount: number; lastUpdate?: Date }> {
+    console.warn('Warning: getTableMetadata is deprecated. Use getRowCount() and getMaxTimestamp() instead.');
+
+    try {
+      const rowCount = await this.getRowCount(tableName);
+      const lastUpdate = await this.getMaxTimestamp(tableName, timestampColumn);
+
+      return {
+        rowCount,
+        lastUpdate: lastUpdate ?? undefined
+      };
+    } catch (error) {
+      throw new QueryError(
+        'Failed to get table metadata',
+        'metadata_query',
+        tableName,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Legacy query method for backward compatibility
+   * @deprecated Direct SQL queries are not allowed for security reasons
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await -- deprecated stub that always throws
+  async query<T = unknown>(_sql: string): Promise<T[]> {
+    throw new Error(
+      'Direct SQL queries are not allowed for security reasons. Use specific methods like getRowCount(), getMaxTimestamp(), etc.'
+    );
+  }
+}

--- a/src/connectors/synapse.ts
+++ b/src/connectors/synapse.ts
@@ -1,0 +1,581 @@
+/**
+ * Secure Azure Synapse Analytics connector for FreshGuard Core
+ * Extends BaseConnector with security built-in
+ * Uses mssql driver with Synapse-specific configuration
+ *
+ * @module @freshguard/freshguard-core/connectors/synapse
+ */
+
+import * as mssql from 'mssql';
+import { BaseConnector } from './base-connector.js';
+import type { ConnectorConfig, TableSchema, SecurityConfig } from '../types/connector.js';
+import { type QueryResultRow, rowString } from '../types/driver-results.js';
+import type { SourceCredentials } from '../types.js';
+import {
+  ConnectionError,
+  TimeoutError,
+  QueryError,
+  ErrorHandler
+} from '../errors/index.js';
+import { validateConnectorConfig } from '../validators/index.js';
+
+/**
+ * Secure Azure Synapse Analytics connector
+ *
+ * Features:
+ * - SQL injection prevention
+ * - Connection timeouts
+ * - SSL always enforced (Azure requirement)
+ * - Read-only query patterns
+ * - Secure error handling
+ * - Synapse-specific DMV support (dm_pdw_exec_requests)
+ */
+export class SynapseConnector extends BaseConnector {
+  private pool: mssql.ConnectionPool | null = null;
+  private connected = false;
+
+  constructor(config: ConnectorConfig, securityConfig?: Partial<SecurityConfig>) {
+    // Validate configuration before proceeding
+    validateConnectorConfig(config);
+    super(config, securityConfig);
+  }
+
+  /**
+   * Connect to Azure Synapse Analytics with security validation
+   */
+  private async connect(): Promise<void> {
+    if (this.connected && this.pool) {
+      return; // Already connected
+    }
+
+    try {
+      const poolConfig: mssql.config = {
+        server: this.config.host,
+        port: this.config.port ?? 1433,
+        database: this.config.database,
+        user: this.config.username,
+        password: this.config.password,
+        options: {
+          // Azure Synapse always requires encryption
+          encrypt: true,
+          trustServerCertificate: false,
+          connectTimeout: this.connectionTimeout,
+          requestTimeout: this.queryTimeout,
+          appName: this.config.applicationName ?? 'freshguard-core'
+        },
+        pool: {
+          max: 1, // Single connection for monitoring
+          min: 0,
+          idleTimeoutMillis: 30000
+        }
+      };
+
+      this.pool = new mssql.ConnectionPool(poolConfig);
+      await this.pool.connect();
+
+      this.connected = true;
+    } catch (error) {
+      throw new ConnectionError(
+        'Failed to connect to Azure Synapse Analytics',
+        this.config.host,
+        this.config.port,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Execute a validated SQL query with security measures
+   */
+  protected async executeQuery(sql: string): Promise<QueryResultRow[]> {
+    return this.executeParameterizedQuery(sql, []);
+  }
+
+  /**
+   * Execute a parameterized SQL query using prepared statements
+   */
+  protected async executeParameterizedQuery(sql: string, parameters: unknown[] = []): Promise<QueryResultRow[]> {
+    await this.connect();
+
+    if (!this.pool) {
+      throw new ConnectionError('Database connection not available');
+    }
+
+    try {
+      const result = await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+
+          // Bind positional parameters as @p1, @p2, etc.
+          for (let i = 0; i < parameters.length; i++) {
+            request.input(`p${i + 1}`, parameters[i]);
+          }
+
+          // Replace $N placeholders with @pN for MSSQL
+          let mssqlSql = sql;
+          for (let i = parameters.length; i >= 1; i--) {
+            mssqlSql = mssqlSql.replace(new RegExp(`\\$${i}`, 'g'), `@p${i}`);
+          }
+          // Also replace ? placeholders with @pN
+          let paramIndex = 0;
+          mssqlSql = mssqlSql.replace(/\?/g, () => `@p${++paramIndex}`);
+
+          const res = await request.query(mssqlSql);
+          return (res.recordset ?? []) as Record<string, unknown>[];
+        },
+        this.queryTimeout
+      );
+
+      // Validate result size for security
+      this.validateResultSize(result);
+
+      return result;
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        throw error;
+      }
+
+      // Sanitize and re-throw as QueryError
+      throw new QueryError(
+        ErrorHandler.getUserMessage(error),
+        'query_execution',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Test database connection with security validation
+   */
+  async testConnection(debugConfig?: import('../types.js').DebugConfig): Promise<boolean> {
+    const mergedDebugConfig = this.mergeDebugConfig(debugConfig);
+    const debugId = `synapse-test-${Date.now().toString(36)}-${Math.random().toString(36).substr(2, 5)}`;
+    const startTime = performance.now();
+
+    try {
+      this.logDebugInfo(mergedDebugConfig, debugId, 'Starting connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        ssl: this.config.ssl
+      });
+
+      await this.connect();
+
+      if (!this.pool) {
+        this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+          error: 'Connection not available after connect',
+          duration: performance.now() - startTime
+        });
+        return false;
+      }
+
+      // Test with a simple, safe query (skip validation for connection test)
+      const sql = 'SELECT 1 AS test';
+
+      await this.executeWithTimeout(
+        async () => {
+          if (!this.pool) throw new ConnectionError('Database connection not available');
+          const request = this.pool.request();
+          return request.query(sql);
+        },
+        this.connectionTimeout
+      );
+
+      const duration = performance.now() - startTime;
+
+      if (mergedDebugConfig?.enabled) {
+        console.log(`[DEBUG-${debugId}] Connection test completed:`, {
+          success: true,
+          duration,
+          host: this.config.host,
+          database: this.config.database
+        });
+      }
+
+      return true;
+    } catch (error) {
+      const duration = performance.now() - startTime;
+
+      this.logDebugError(mergedDebugConfig, debugId, 'Connection test', {
+        host: this.config.host,
+        port: this.config.port,
+        database: this.config.database,
+        error: mergedDebugConfig?.exposeRawErrors && error instanceof Error ? error.message : 'Connection failed',
+        duration,
+        suggestion: this.generateConnectionSuggestion(error)
+      });
+
+      // Don't throw - this method should return boolean
+      return false;
+    }
+  }
+
+  /**
+   * Helper method to merge debug configuration
+   */
+  private mergeDebugConfig(debugConfig?: import('../types.js').DebugConfig): import('../types.js').DebugConfig {
+    return {
+      enabled: debugConfig?.enabled ?? (process.env.NODE_ENV === 'development'),
+      exposeQueries: debugConfig?.exposeQueries ?? true,
+      exposeRawErrors: debugConfig?.exposeRawErrors ?? true,
+      logLevel: debugConfig?.logLevel ?? 'debug'
+    };
+  }
+
+  /**
+   * Generate connection suggestions based on error (Synapse-specific)
+   */
+  private generateConnectionSuggestion(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return 'Check database connection configuration';
+    }
+
+    const message = error.message.toLowerCase();
+
+    if (message.includes('connect econnrefused') || message.includes('connection refused')) {
+      return `Azure Synapse at ${this.config.host}:${this.config.port} is not accepting connections. Verify the SQL pool is running and check firewall rules.`;
+    }
+
+    if (message.includes('timeout') || message.includes('connect timeout')) {
+      return `Connection timeout to ${this.config.host}:${this.config.port}. The SQL pool may be paused or scaling. Check pool status and firewall rules.`;
+    }
+
+    if (message.includes('login failed') || message.includes('authentication failed')) {
+      return `Authentication failed for database '${this.config.database}'. Verify username, password, and Azure AD configuration if using AAD auth.`;
+    }
+
+    if (message.includes('cannot open database') || (message.includes('database') && message.includes('not exist'))) {
+      return `Database '${this.config.database}' not found. Check database name on your Azure Synapse workspace.`;
+    }
+
+    if (message.includes('ssl') || message.includes('tls') || message.includes('encrypt')) {
+      return `SSL/TLS connection issue. Azure Synapse requires encryption - check SSL certificate configuration.`;
+    }
+
+    if (message.includes('firewall')) {
+      return `Connection blocked by firewall. Add your client IP address to the Synapse workspace firewall rules.`;
+    }
+
+    if (message.includes('paused') || message.includes('suspended') || message.includes('resuming')) {
+      return `SQL pool appears to be paused or resuming. Resume the dedicated SQL pool in the Azure portal and wait for it to become available.`;
+    }
+
+    if (message.includes('dwu') || message.includes('capacity')) {
+      return `SQL pool capacity issue. Check DWU settings and consider scaling up your dedicated SQL pool.`;
+    }
+
+    return `Connection failed to ${this.config.host}:${this.config.port}. Check host, port, credentials, SQL pool status, and network connectivity.`;
+  }
+
+  /**
+   * List all tables in the database (including external tables)
+   */
+  async listTables(): Promise<string[]> {
+    const sql = `
+      SELECT TABLE_NAME as table_name
+      FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_TYPE = 'BASE TABLE'
+        AND TABLE_SCHEMA = 'dbo'
+      ORDER BY TABLE_NAME
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      return result
+        .slice(0, this.maxRows)
+        .map((row) => rowString(row.table_name ?? row.TABLE_NAME ?? row.tablename))
+        .filter(Boolean);
+    } catch (error) {
+      throw new QueryError(
+        'Failed to list tables',
+        'table_listing',
+        undefined,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get table schema information securely
+   */
+  async getTableSchema(table: string): Promise<TableSchema> {
+    // Validate table name (identifiers cannot be parameterized)
+    this.escapeIdentifier(table);
+
+    const sql = `
+      SELECT
+        COLUMN_NAME as column_name,
+        DATA_TYPE as data_type,
+        IS_NULLABLE as is_nullable
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = 'dbo'
+        AND TABLE_NAME = '${table}'
+      ORDER BY ORDINAL_POSITION
+    `;
+
+    await this.validateQuery(sql);
+
+    try {
+      const result = await this.executeQuery(sql);
+      const limited = result.slice(0, this.maxRows);
+
+      if (limited.length === 0) {
+        throw QueryError.tableNotFound(table);
+      }
+
+      return {
+        table,
+        columns: limited.map(row => ({
+          name: rowString(row.column_name ?? row.COLUMN_NAME),
+          type: this.mapSynapseType(rowString(row.data_type ?? row.DATA_TYPE)),
+          nullable: (row.is_nullable ?? row.IS_NULLABLE) === 'YES'
+        }))
+      };
+    } catch (error) {
+      if (error instanceof QueryError) {
+        throw error;
+      }
+
+      throw new QueryError(
+        'Failed to get table schema',
+        'schema_query',
+        table,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Get last modified timestamp using Synapse-specific methods
+   */
+  async getLastModified(table: string): Promise<Date | null> {
+    // Try common timestamp columns
+    const timestampColumns = ['updated_at', 'modified_at', 'last_modified', 'timestamp'];
+
+    for (const column of timestampColumns) {
+      try {
+        const result = await this.getMaxTimestamp(table, column);
+        if (result) {
+          return result;
+        }
+      } catch {
+        // Column doesn't exist, try next one
+        continue;
+      }
+    }
+
+    // Fallback: use Synapse DMV for recent requests against this table
+    try {
+      const sql = `
+        SELECT MAX(end_time) as last_modified
+        FROM sys.dm_pdw_exec_requests
+        WHERE command LIKE '%${this.escapeIdentifier(table).replace(/\[|\]/g, '')}%'
+          AND status = 'Completed'
+          AND resource_class IS NOT NULL
+      `;
+
+      await this.validateQuery(sql);
+      const result = await this.executeQuery(sql);
+
+      if (result.length > 0 && result[0]?.last_modified) {
+        return new Date(rowString(result[0].last_modified));
+      }
+    } catch {
+      // DMV query failed, return null
+    }
+
+    return null;
+  }
+
+  /**
+   * Close the database connection
+   */
+  async close(): Promise<void> {
+    if (this.pool) {
+      try {
+        await this.pool.close();
+      } catch (error) {
+        // Log error but don't throw - closing should be safe
+        console.warn('Warning: Error closing Synapse connection:', ErrorHandler.getUserMessage(error));
+      } finally {
+        this.pool = null;
+        this.connected = false;
+      }
+    }
+  }
+
+  /**
+   * Map Synapse data types to standard types
+   * Includes Synapse-specific types alongside standard SQL Server types
+   */
+  private mapSynapseType(synapseType: string): string {
+    const typeMap: Record<string, string> = {
+      // Numeric types
+      'tinyint': 'integer',
+      'smallint': 'integer',
+      'int': 'integer',
+      'integer': 'integer',
+      'bigint': 'bigint',
+      'decimal': 'decimal',
+      'numeric': 'decimal',
+      'money': 'decimal',
+      'smallmoney': 'decimal',
+      'float': 'float',
+      'real': 'float',
+      'bit': 'boolean',
+
+      // String types
+      'char': 'text',
+      'varchar': 'text',
+      'text': 'text',
+      'nchar': 'text',
+      'nvarchar': 'text',
+      'ntext': 'text',
+
+      // Date/time types
+      'date': 'date',
+      'time': 'time',
+      'datetime': 'timestamp',
+      'datetime2': 'timestamp',
+      'smalldatetime': 'timestamp',
+      'datetimeoffset': 'timestamptz',
+
+      // Binary types
+      'binary': 'text',
+      'varbinary': 'text',
+      'image': 'text',
+
+      // Special types
+      'uniqueidentifier': 'text',
+      'xml': 'text',
+      'sql_variant': 'text',
+      'hierarchyid': 'text',
+      'geometry': 'text',
+      'geography': 'text',
+      'timestamp': 'text',
+      'rowversion': 'text'
+    };
+
+    return typeMap[synapseType.toLowerCase()] ?? 'unknown';
+  }
+
+  /**
+   * Override escapeIdentifier for SQL Server bracket notation
+   */
+  protected escapeIdentifier(identifier: string): string {
+    // Only allow alphanumeric, underscore, and dot (for schema.table)
+    if (!/^[a-zA-Z0-9_.]+$/.test(identifier)) {
+      throw new Error(`Invalid identifier: ${identifier}`);
+    }
+
+    // Additional length check
+    if (identifier.length > 256) {
+      throw new Error('Identifier too long');
+    }
+
+    // Return with brackets for SQL Server
+    return `[${identifier}]`;
+  }
+
+  // ==============================================
+  // Legacy API compatibility methods
+  // ==============================================
+
+  /**
+   * Legacy connect method for backward compatibility
+   * @deprecated Use constructor with ConnectorConfig instead
+   */
+  async connectLegacy(credentials: SourceCredentials): Promise<void> {
+    console.warn('Warning: connectLegacy is deprecated. Use constructor with ConnectorConfig instead.');
+
+    // Convert legacy credentials to new format
+    const config: ConnectorConfig = {
+      host: credentials.host ?? '',
+      port: credentials.port ?? 1433,
+      database: credentials.database ?? '',
+      username: credentials.username ?? '',
+      password: credentials.password ?? '',
+      ssl: credentials.sslMode !== 'disable'
+    };
+
+    // Validate and reconnect
+    validateConnectorConfig(config);
+    this.config = { ...this.config, ...config };
+    await this.connect();
+  }
+
+  /**
+   * Legacy test connection method for backward compatibility
+   * @deprecated Use testConnection() instead
+   */
+  async testConnectionLegacy(): Promise<{ success: boolean; tableCount?: number; error?: string }> {
+    console.warn('Warning: testConnectionLegacy is deprecated. Use testConnection() instead.');
+
+    try {
+      const success = await this.testConnection();
+
+      if (success) {
+        // Get table count for legacy compatibility
+        const tables = await this.listTables();
+        return {
+          success: true,
+          tableCount: tables.length
+        };
+      } else {
+        return {
+          success: false,
+          error: 'Connection test failed'
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: ErrorHandler.getUserMessage(error)
+      };
+    }
+  }
+
+  /**
+   * Legacy get table metadata method for backward compatibility
+   * @deprecated Use getRowCount() and getMaxTimestamp() instead
+   */
+  async getTableMetadata(
+    tableName: string,
+    timestampColumn = 'updated_at'
+  ): Promise<{ rowCount: number; lastUpdate?: Date }> {
+    console.warn('Warning: getTableMetadata is deprecated. Use getRowCount() and getMaxTimestamp() instead.');
+
+    try {
+      const rowCount = await this.getRowCount(tableName);
+      const lastUpdate = await this.getMaxTimestamp(tableName, timestampColumn);
+
+      return {
+        rowCount,
+        lastUpdate: lastUpdate ?? undefined
+      };
+    } catch (error) {
+      throw new QueryError(
+        'Failed to get table metadata',
+        'metadata_query',
+        tableName,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Legacy query method for backward compatibility
+   * @deprecated Direct SQL queries are not allowed for security reasons
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await -- deprecated stub that always throws
+  async query<T = unknown>(_sql: string): Promise<T[]> {
+    throw new Error(
+      'Direct SQL queries are not allowed for security reasons. Use specific methods like getRowCount(), getMaxTimestamp(), etc.'
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@
  * FreshGuard Core - Open Source Data Pipeline Freshness Monitoring
  *
  * Monitor data pipeline freshness, volume anomalies, and schema changes across
- * PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, and Redshift.
+ * PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, Redshift, SQL Server, Azure SQL,
+ * and Azure Synapse.
  *
  * @example
  * ```typescript
@@ -33,7 +34,7 @@
 export { checkFreshness, checkVolumeAnomaly, checkSchemaChanges } from './monitor/index.js';
 
 // Database connectors
-export { PostgresConnector, DuckDBConnector, BigQueryConnector, SnowflakeConnector, MySQLConnector, RedshiftConnector } from './connectors/index.js';
+export { PostgresConnector, DuckDBConnector, BigQueryConnector, SnowflakeConnector, MySQLConnector, RedshiftConnector, MSSQLConnector, AzureSQLConnector, SynapseConnector } from './connectors/index.js';
 
 // Database utilities
 export { createDatabase, schema } from './db/index.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@
 // Core Data Structures
 // ==============================================
 
-export type DataSourceType = 'postgres' | 'duckdb' | 'bigquery' | 'snowflake';
+export type DataSourceType = 'postgres' | 'duckdb' | 'bigquery' | 'snowflake' | 'mysql' | 'redshift' | 'mssql' | 'azure_sql' | 'synapse';
 export type RuleType = 'freshness' | 'volume_anomaly' | 'schema_change' | 'custom_sql';
 export type CheckStatus = 'ok' | 'alert' | 'failed' | 'pending';
 export type AlertDestinationType = 'slack' | 'email' | 'pagerduty' | 'webhook';

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -180,6 +180,11 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
     /^SELECT\s+tablename\s+FROM\s+pg_tables/is,                                          // Redshift table listing using pg_tables
     /^SELECT\s+[\s\S]*?FROM\s+svv_table_info/is,                                         // Redshift system view queries
 
+    // MSSQL/Azure SQL/Synapse patterns
+    /^SELECT\s+.+?\s+FROM\s+INFORMATION_SCHEMA\.\w+/is,                                   // MSSQL INFORMATION_SCHEMA (uppercase)
+    /^SELECT\s+.+?\s+FROM\s+sys\.\w+/is,                                                   // MSSQL system views
+    /^SELECT\s+.+?\s+FROM\s+sys\.dm_\w+/is,                                                // MSSQL dynamic management views
+
     // Test connection queries
     /^SELECT\s+1(?:\s+as\s+\w+)?$/i,                                                     // SELECT 1 [as alias] (connection test)
   ],
@@ -197,7 +202,7 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
 /**
  * Database connector types supported by FreshGuard Core
  */
-export type ConnectorType = 'postgres' | 'duckdb' | 'bigquery' | 'snowflake' | 'mysql' | 'redshift';
+export type ConnectorType = 'postgres' | 'duckdb' | 'bigquery' | 'snowflake' | 'mysql' | 'redshift' | 'mssql' | 'azure_sql' | 'synapse';
 
 /**
  * Connector factory configuration

--- a/website/docs/examples/multi-database.md
+++ b/website/docs/examples/multi-database.md
@@ -12,6 +12,7 @@ import {
   PostgresConnector,
   BigQueryConnector,
   SnowflakeConnector,
+  MSSQLConnector,
 } from '@freshguard/freshguard-core';
 import type { MonitoringRule } from '@freshguard/freshguard-core';
 
@@ -35,6 +36,14 @@ const connectors = {
     database: 'ANALYTICS',
     username: process.env.SNOWFLAKE_USER!,
     password: process.env.SNOWFLAKE_PASSWORD!,
+    ssl: true,
+  }),
+  sqlserver: new MSSQLConnector({
+    host: process.env.MSSQL_HOST!,
+    port: Number(process.env.MSSQL_PORT) || 1433,
+    database: process.env.MSSQL_DB!,
+    username: process.env.MSSQL_USER!,
+    password: process.env.MSSQL_PASSWORD!,
     ssl: true,
   }),
 };
@@ -84,6 +93,22 @@ const rules: Array<{ connector: keyof typeof connectors; rule: MonitoringRule }>
       toleranceMinutes: 90,
       timestampColumn: 'CREATED_AT',
       checkIntervalMinutes: 10,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  },
+  {
+    connector: 'sqlserver',
+    rule: {
+      id: 'mssql-inventory',
+      sourceId: 'sqlserver',
+      name: 'SQL Server Inventory',
+      tableName: 'inventory',
+      ruleType: 'freshness',
+      toleranceMinutes: 30,
+      timestampColumn: 'updated_at',
+      checkIntervalMinutes: 5,
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ The package exports:
 | Category | Exports |
 |---|---|
 | **Monitoring** | `checkFreshness`, `checkVolumeAnomaly`, `checkSchemaChanges` |
-| **Connectors** | `PostgresConnector`, `DuckDBConnector`, `BigQueryConnector`, `SnowflakeConnector`, `MySQLConnector`, `RedshiftConnector` |
+| **Connectors** | `PostgresConnector`, `DuckDBConnector`, `BigQueryConnector`, `SnowflakeConnector`, `MySQLConnector`, `RedshiftConnector`, `MSSQLConnector`, `AzureSQLConnector`, `SynapseConnector` |
 | **Metadata** | `createMetadataStorage`, `DuckDBMetadataStorage`, `PostgreSQLMetadataStorage` |
 | **Errors** | `SecurityError`, `ConnectionError`, `TimeoutError`, `QueryError`, `ConfigurationError`, `MonitoringError` |
 | **Types** | `MonitoringRule`, `CheckResult`, `DataSource`, `FreshGuardConfig`, and more |

--- a/website/docs/guides/connectors.md
+++ b/website/docs/guides/connectors.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Database Connectors
 
-FreshGuard Core supports six databases. All connectors extend `BaseConnector`, which provides built-in query validation, timeout protection, error sanitization, and structured logging.
+FreshGuard Core supports nine databases. All connectors extend `BaseConnector`, which provides built-in query validation, timeout protection, error sanitization, and structured logging.
 
 ## PostgreSQL
 
@@ -106,6 +106,55 @@ const connector = new RedshiftConnector({
   ssl: true,
 });
 ```
+
+## SQL Server
+
+```typescript
+import { MSSQLConnector } from '@freshguard/freshguard-core';
+
+const connector = new MSSQLConnector({
+  host: process.env.MSSQL_HOST!,
+  port: Number(process.env.MSSQL_PORT) || 1433,
+  database: process.env.MSSQL_DB!,
+  username: process.env.MSSQL_USER!,
+  password: process.env.MSSQL_PASSWORD!,
+  ssl: true,
+});
+```
+
+## Azure SQL Database
+
+Azure SQL always enforces SSL encryption:
+
+```typescript
+import { AzureSQLConnector } from '@freshguard/freshguard-core';
+
+const connector = new AzureSQLConnector({
+  host: 'your-server.database.windows.net',
+  port: 1433,
+  database: process.env.AZURE_SQL_DB!,
+  username: process.env.AZURE_SQL_USER!,
+  password: process.env.AZURE_SQL_PASSWORD!,
+  ssl: true,
+});
+```
+
+## Azure Synapse Analytics
+
+```typescript
+import { SynapseConnector } from '@freshguard/freshguard-core';
+
+const connector = new SynapseConnector({
+  host: 'your-workspace.sql.azuresynapse.net',
+  port: 1433,
+  database: process.env.SYNAPSE_DB!,
+  username: process.env.SYNAPSE_USER!,
+  password: process.env.SYNAPSE_PASSWORD!,
+  ssl: true,
+});
+```
+
+Ensure the dedicated SQL pool is running before connecting — paused pools will cause connection timeouts.
 
 ## Connector interface
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 # Introduction
 
-FreshGuard Core is an open-source, MIT-licensed data pipeline freshness monitoring engine. It detects stale data, volume anomalies, and schema changes across PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, and Redshift.
+FreshGuard Core is an open-source, MIT-licensed data pipeline freshness monitoring engine. It detects stale data, volume anomalies, and schema changes across PostgreSQL, DuckDB, BigQuery, Snowflake, MySQL, Redshift, SQL Server, Azure SQL, and Azure Synapse.
 
 ## What it does
 
@@ -28,7 +28,7 @@ Monitoring Algorithms
   checkFreshness · checkVolumeAnomaly · checkSchemaChanges
         |
 Database Connectors
-  PostgreSQL · DuckDB · BigQuery · Snowflake · MySQL · Redshift
+  PostgreSQL · DuckDB · BigQuery · Snowflake · MySQL · Redshift · SQL Server · Azure SQL · Azure Synapse
         |
 Metadata Storage (optional)
   DuckDB (embedded) or PostgreSQL


### PR DESCRIPTION
## Summary

- Add three Microsoft database connectors using the `mssql` npm package (MIT licensed):
  - **`MSSQLConnector`** — SQL Server with bracket notation escaping and `sys.dm_db_index_usage_stats` fallback
  - **`AzureSQLConnector`** — Azure SQL Database with SSL always enforced and Azure-specific error hints (firewall rules, AAD)
  - **`SynapseConnector`** — Azure Synapse Analytics with `sys.dm_pdw_exec_requests` fallback and pool-paused error hints
- Update `DataSourceType` and `ConnectorType` to include all 9 supported databases
- Add MSSQL-specific allowed query patterns for `INFORMATION_SCHEMA` and `sys.*` views
- Bump version from 0.13.2 to 0.14.0
- Update all documentation: README, ARCHITECTURE, CONTRIBUTING, SELF_HOSTING, and website docs (intro, connectors guide, installation, multi-database example)

## Test plan

- [x] All 3 connectors instantiate with valid config
- [x] Invalid config rejection (empty host, bad port, missing SSL)
- [x] Interface method existence checks for all connectors
- [x] Direct SQL query blocking for security
- [x] Connector Security Consistency tests include all 9 connectors
- [x] `pnpm build` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:coverage` — 557 tests pass, coverage thresholds met
- [x] Documentation website builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)