### PR TITLE
fix: BigQuery listTables and getTableSchema fail due to parameterized identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshguard/freshguard-core",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Fixes `BigQueryConnector.listTables()` and `getTableSchema()` which always failed because they used parameterized query placeholders (`$1`, `$2`) inside backtick-quoted identifiers — BigQuery does not support this
- Project/dataset IDs are now interpolated directly into the SQL strings, which is safe because they are validated against strict regex patterns in the constructor and `parseTableName()`
- Also fixes the `table_type` filter value from `'BASE_TABLE'` to `'BASE TABLE'` (correct BigQuery value)
- Bumps version to 0.15.2

Closes #47

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:coverage` passes (557 passed, 8 skipped)
- [ ] Manual verification with a real BigQuery project and service account credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)