### PR TITLE
feat: add setDataset()/getDataset() to BigQueryConnector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-02-16
+
+### Added
+- `BigQueryConnector.setDataset()` / `getDataset()` to scope `listTables()` to a single dataset (#54)
+- `options.dataset` support in `ConnectorConfig` for BigQuery — required when the service account only has dataset-level permissions
+
 ## [0.15.5] - 2026-02-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ if (result.status === 'alert') {
 | `AzureSQLConnector` | Azure SQL Database |
 | `SynapseConnector` | Azure Synapse Analytics |
 
-All connectors accept a `ConnectorConfig` (host, port, database, username, password, ssl) and an optional `SecurityConfig` override. Pass connector-specific settings via `options` — e.g., `options: { schema: 'staging' }` for non-default schemas, `options: { location: 'EU' }` for BigQuery region, or `options: { warehouse: 'COMPUTE_WH' }` for Snowflake.
+All connectors accept a `ConnectorConfig` (host, port, database, username, password, ssl) and an optional `SecurityConfig` override. Pass connector-specific settings via `options` — e.g., `options: { schema: 'staging' }` for non-default schemas, `options: { location: 'EU' }` for BigQuery region, `options: { dataset: 'my_dataset' }` to scope BigQuery to a single dataset, or `options: { warehouse: 'COMPUTE_WH' }` for Snowflake.
 
 ### Metadata storage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -160,7 +160,7 @@ interface ConnectorConfig {
 |---|---|---|
 | `PostgresConnector` | Standard PostgreSQL | `schema` (default: `'public'`) |
 | `DuckDBConnector` | `database` = file path or `':memory:'` | — |
-| `BigQueryConnector` | `database` = GCP project ID | `location` (default: auto-detected, fallback `'US'`) |
+| `BigQueryConnector` | `database` = GCP project ID | `location` (default: auto-detected, fallback `'US'`), `dataset` (scope `listTables()` to one dataset) |
 | `SnowflakeConnector` | `host` = `<account>.snowflakecomputing.com` | `schema` (default: `'PUBLIC'`), `warehouse` |
 | `MySQLConnector` | Standard MySQL, port 3306 | — |
 | `RedshiftConnector` | PostgreSQL wire protocol, port 5439 | `schema` (default: `'public'`) |
@@ -186,6 +186,14 @@ const bq = new BigQueryConnector({
   database: 'my-gcp-project', username: 'bigquery',
   password: serviceAccountJson,
   options: { location: 'EU' },
+});
+
+// Example: BigQuery scoped to a single dataset
+const bqScoped = new BigQueryConnector({
+  host: 'bigquery.googleapis.com', port: 443,
+  database: 'my-gcp-project', username: 'bigquery',
+  password: serviceAccountJson,
+  options: { dataset: 'my_dataset' },
 });
 
 // Example: SQL Server with custom schema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshguard/freshguard-core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -42,6 +42,7 @@ export interface ConnectorConfig {
    * | Connector | Key | Default | Description |
    * |-----------|-----|---------|-------------|
    * | BigQuery | `location` | auto-detected / `'US'` | Dataset region |
+   * | BigQuery | `dataset` | *(none — project-wide)* | Scope `listTables()` to a single dataset |
    * | Snowflake | `schema` | `'PUBLIC'` | Target schema |
    * | Snowflake | `warehouse` | `''` | Compute warehouse |
    * | PostgreSQL | `schema` | `'public'` | Target schema |

--- a/tests/connectors.test.ts
+++ b/tests/connectors.test.ts
@@ -317,6 +317,60 @@ describe('BigQueryConnector Security', () => {
     connector.setLocation('asia-east1');
     expect(connector.getLocation()).toBe('asia-east1');
   });
+
+  it('should accept dataset from config options', () => {
+    const connector = new BigQueryConnector({
+      ...validBigQueryConfig,
+      options: { dataset: 'my_dataset' },
+    });
+    expect(connector.getDataset()).toBe('my_dataset');
+  });
+
+  it('should default dataset to undefined when not specified', () => {
+    const connector = new BigQueryConnector(validBigQueryConfig);
+    expect(connector.getDataset()).toBeUndefined();
+  });
+
+  it('should allow setting dataset via setDataset', () => {
+    const connector = new BigQueryConnector(validBigQueryConfig);
+    connector.setDataset('analytics');
+    expect(connector.getDataset()).toBe('analytics');
+  });
+
+  it('should allow overriding dataset via setDataset', () => {
+    const connector = new BigQueryConnector({
+      ...validBigQueryConfig,
+      options: { dataset: 'original' },
+    });
+    connector.setDataset('updated');
+    expect(connector.getDataset()).toBe('updated');
+  });
+
+  it('should ignore non-string dataset values in options', () => {
+    const connector = new BigQueryConnector({
+      ...validBigQueryConfig,
+      options: { dataset: 42 },
+    });
+    expect(connector.getDataset()).toBeUndefined();
+  });
+
+  it('should reject invalid dataset identifiers via setDataset', () => {
+    const connector = new BigQueryConnector(validBigQueryConfig);
+    expect(() => connector.setDataset('DROP TABLE; --')).toThrow();
+  });
+
+  it('should reject invalid dataset identifiers from config options', () => {
+    expect(() => new BigQueryConnector({
+      ...validBigQueryConfig,
+      options: { dataset: 'DROP TABLE; --' },
+    })).toThrow();
+  });
+
+  it('should have setDataset and getDataset methods', () => {
+    const connector = new BigQueryConnector(validBigQueryConfig);
+    expect(connector.setDataset).toBeDefined();
+    expect(connector.getDataset).toBeDefined();
+  });
 });
 
 describe('SnowflakeConnector Security', () => {


### PR DESCRIPTION
## Summary

Closes #54

- Adds `setDataset()` / `getDataset()` methods to `BigQueryConnector`, following the existing `setLocation()` / `getLocation()` pattern
- Adds `options.dataset` support in the constructor for initial configuration
- When a dataset is set, `listTables()` queries `{project}.{dataset}.INFORMATION_SCHEMA.TABLES` (dataset-scoped) instead of `{project}.INFORMATION_SCHEMA.TABLES` (project-wide)
- When no dataset is set, behavior is unchanged (project-wide listing)
- Bumps version to 0.17.0

## Test plan

- [x] New unit tests for `setDataset()` / `getDataset()` (8 tests added)
- [x] Invalid dataset identifiers are rejected via `validateTableName()`
- [x] Non-string `options.dataset` values are ignored
- [x] All 584 existing tests pass, coverage thresholds met
- [ ] Manual integration test with BigQuery service account that has dataset-level permissions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)