### PR TITLE
fix: support schema-qualified table names in query validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshguard/freshguard-core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -174,14 +174,19 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
   requireSSL: true,
   /* eslint-disable security/detect-unsafe-regex -- These are SQL query validation patterns, intentionally complex */
   allowedQueryPatterns: [
-    // FreshGuard Core monitoring patterns (v0.9.1+) - Updated to handle all whitespace and quoted identifiers
-    /^SELECT\s+COUNT\(\*\)(?:\s+as\s+\w+)?\s+FROM\s+[`"]?\w+[`"]?$/is,                    // getRowCount: SELECT COUNT(*) [as alias] FROM table
-    /^SELECT\s+MAX\([`"]?\w+[`"]?\)(?:\s+as\s+\w+)?\s+FROM\s+[`"]?\w+[`"]?$/is,           // getMaxTimestamp: SELECT MAX(column) [as alias] FROM table
-    /^SELECT\s+MIN\([`"]?\w+[`"]?\)(?:\s+as\s+\w+)?\s+FROM\s+[`"]?\w+[`"]?$/is,           // getMinTimestamp: SELECT MIN(column) [as alias] FROM table
+    // FreshGuard Core monitoring patterns (v0.9.1+)
+    // Table identifier pattern supports all connector quoting styles:
+    //   unquoted:  schema.table, project.dataset.table
+    //   backticks: `schema.table` (MySQL, BigQuery)
+    //   brackets:  [schema.table] (MSSQL, Azure SQL, Synapse)
+    //   quotes:    "schema.table" (PostgreSQL, Redshift)
+    /^SELECT\s+COUNT\(\*\)(?:\s+as\s+\w+)?\s+FROM\s+(?:[`"][\w.]+[`"]|\[[\w.]+\]|\w+(?:\.\w+)*)$/is,                    // getRowCount
+    /^SELECT\s+MAX\((?:[`"]\w+[`"]|\[\w+\]|\w+)\)(?:\s+as\s+\w+)?\s+FROM\s+(?:[`"][\w.]+[`"]|\[[\w.]+\]|\w+(?:\.\w+)*)$/is,           // getMaxTimestamp
+    /^SELECT\s+MIN\((?:[`"]\w+[`"]|\[\w+\]|\w+)\)(?:\s+as\s+\w+)?\s+FROM\s+(?:[`"][\w.]+[`"]|\[[\w.]+\]|\w+(?:\.\w+)*)$/is,           // getMinTimestamp
 
     // Schema introspection queries
-    /^DESCRIBE\s+[`"]?\w+[`"]?$/i,                                                         // DESCRIBE table
-    /^SHOW\s+(TABLES|COLUMNS)(?:\s+FROM\s+[`"]?\w+[`"]?)?$/i,                            // SHOW TABLES, SHOW COLUMNS FROM table
+    /^DESCRIBE\s+(?:[`"][\w.]+[`"]|\[[\w.]+\]|\w+(?:\.\w+)*)$/i,                                              // DESCRIBE [schema.]table
+    /^SHOW\s+(TABLES|COLUMNS)(?:\s+FROM\s+(?:[`"][\w.]+[`"]|\[[\w.]+\]|\w+(?:\.\w+)*))?$/i,                   // SHOW TABLES/COLUMNS
 
     // Information schema queries (cross-database compatibility)
     /^SELECT\s+.+?\s+FROM\s+information_schema\.\w+/is,                                  // PostgreSQL/MySQL information_schema


### PR DESCRIPTION
## Summary

- Fixed SQL query validation patterns that rejected schema-qualified table names (e.g. `dataset.table`, `schema.table`, `project.dataset.table`)
- Updated all monitoring patterns (COUNT, MAX, MIN) and introspection patterns (DESCRIBE, SHOW) to support every connector's quoting style: unquoted dotted, backtick-quoted, double-quote-quoted, and bracket-quoted
- Bumped version to 0.17.1

Fixes a production issue where BigQuery queries like `SELECT COUNT(*) as count FROM dbt_mandersson.fct_orders` were rejected with "Query pattern not allowed" despite `escapeIdentifier()` already allowing dots in identifiers.

## Test plan

- [x] Added test for schema-qualified names across all connector quoting styles (30+ query variants)
- [x] Added test verifying injection attempts with schema-qualified names are still blocked
- [x] All 586 existing tests pass
- [x] Build and type-check clean
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)