### PR TITLE
fix: remove jobTimeoutMs from BigQuery query options (#57)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshguard/freshguard-core",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Open source data freshness monitoring engine",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/connectors/bigquery.ts
+++ b/src/connectors/bigquery.ts
@@ -230,7 +230,11 @@ export class BigQueryConnector extends BaseConnector {
         query: finalSql,
         location: this.location,
         maxResults: this.maxRows,
-        jobTimeoutMs: this.queryTimeout,
+        // jobTimeoutMs intentionally omitted — setting it forces the
+        // @google-cloud/bigquery client to use the slow query path
+        // (jobs.insert + getQueryResults) which creates anonymous temp
+        // tables that can fail with permission errors.  Timeout
+        // protection is already provided by executeWithTimeout(). (#57)
         useLegacySql: false, // Force standard SQL for security
       };
 


### PR DESCRIPTION
## Summary

- Remove `jobTimeoutMs` from BigQuery query options in `executeParameterizedQuery()` to enable the fast query path (`jobs.query` with inline results)
- Setting `jobTimeoutMs` forced the `@google-cloud/bigquery` client to use the slow path (`jobs.insert` + `getQueryResults`), which creates anonymous temp tables that can fail with permission errors even with correct IAM roles
- Timeout protection is already enforced by the `executeWithTimeout()` wrapper, so there is no loss of functionality
- Bump version to 0.17.2

Fixes #57

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:coverage` passes (586 tests, 24 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)